### PR TITLE
TrailRibbon update to behave better when attached to pooled entity

### DIFF
--- a/Nez-PCL/ECS/Components/Renderables/TrailRibbon.cs
+++ b/Nez-PCL/ECS/Components/Renderables/TrailRibbon.cs
@@ -136,7 +136,7 @@ namespace Nez
 			_areVertsDirty = false;
 		}
 
-		public override void onEnabled ()
+		public override void onEnabled()
 		{
 			base.onEnabled();
 

--- a/Nez-PCL/ECS/Components/Renderables/TrailRibbon.cs
+++ b/Nez-PCL/ECS/Components/Renderables/TrailRibbon.cs
@@ -136,6 +136,13 @@ namespace Nez
 			_areVertsDirty = false;
 		}
 
+		public override void onEnabled ()
+		{
+			base.onEnabled();
+
+			_segments.Clear();
+			initializeVertices();
+		}
 
 		public override void onAddedToEntity()
 		{


### PR DESCRIPTION
Overrode onEnable to clear segments and re-initialize vertices so trail would reset when needed. This is useful when trail is attached to Pooled entity

#46 #