### PR TITLE
UI clipping fixes

### DIFF
--- a/Nez-PCL/UI/Containers/ScrollPane.cs
+++ b/Nez-PCL/UI/Containers/ScrollPane.cs
@@ -1223,7 +1223,7 @@ namespace Nez.UI
 
 			// caculate the scissor bounds based on the batch transform, the available widget area and the camera transform. We need to
 			// project those to screen coordinates for OpenGL to consume.
-			var scissor = ScissorStack.calculateScissors( stage?.entity?.scene?.camera, graphics.batcher.transformMatrix, _widgetAreaBounds );
+			var scissor = ScissorStack.calculateScissors( stage?.camera, graphics.batcher.transformMatrix, _widgetAreaBounds );
 			if( ScissorStack.pushScissors( scissor ) )
 			{
 				graphics.batcher.enableScissorTest( true );
@@ -1265,7 +1265,7 @@ namespace Nez.UI
 			if( transform )
 				applyTransform( graphics, computeTransform() );
 
-			var scissor = ScissorStack.calculateScissors( stage?.entity?.scene?.camera, graphics.batcher.transformMatrix, _widgetAreaBounds );
+			var scissor = ScissorStack.calculateScissors( stage?.camera, graphics.batcher.transformMatrix, _widgetAreaBounds );
 			if( ScissorStack.pushScissors( scissor ) )
 			{
 				graphics.batcher.enableScissorTest( true );

--- a/Nez-PCL/UI/Containers/SplitPane.cs
+++ b/Nez-PCL/UI/Containers/SplitPane.cs
@@ -172,7 +172,7 @@ namespace Nez.UI
 				applyTransform( graphics, computeTransform() );
 			if( _firstWidget != null && _firstWidget.isVisible() )
 			{
-				var scissor = ScissorStack.calculateScissors( stage?.entity?.scene?.camera, graphics.batcher.transformMatrix, _firstWidgetBounds );
+				var scissor = ScissorStack.calculateScissors( stage?.camera, graphics.batcher.transformMatrix, _firstWidgetBounds );
 				if( ScissorStack.pushScissors( scissor ) )
 				{
 					graphics.batcher.enableScissorTest( true );
@@ -184,7 +184,7 @@ namespace Nez.UI
 
 			if( _secondWidget != null && _secondWidget.isVisible() )
 			{
-				var scissor = ScissorStack.calculateScissors( stage?.entity?.scene?.camera, graphics.batcher.transformMatrix, _secondWidgetBounds );
+				var scissor = ScissorStack.calculateScissors( stage?.camera, graphics.batcher.transformMatrix, _secondWidgetBounds );
 				if( ScissorStack.pushScissors( scissor ) )
 				{
 					graphics.batcher.enableScissorTest( true );

--- a/Nez-PCL/UI/Stage.cs
+++ b/Nez-PCL/UI/Stage.cs
@@ -32,7 +32,7 @@ namespace Nez.UI
 		public Keys keyboardActionKey = Keys.Enter;
 
 		Group root;
-		Camera _camera;
+		public Camera camera;
 		bool debugAll, debugUnderMouse, debugParentUnderMouse;
 		Table.TableDebug debugTableUnderMouse = Table.TableDebug.None;
 
@@ -73,7 +73,7 @@ namespace Nez.UI
 			if( !root.isVisible() )
 				return;
 
-			_camera = camera;
+			this.camera = camera;
 			root.draw( graphics, 1f );
 
 			if( debug )
@@ -628,9 +628,9 @@ namespace Nez.UI
 		/// <param name="screenCoords">Screen coords.</param>
 		public Vector2 screenToStageCoordinates( Vector2 screenCoords )
 		{
-			if( _camera == null )
+			if( camera == null )
 				return screenCoords;
-			return _camera.screenToWorldPoint( screenCoords );
+			return camera.screenToWorldPoint( screenCoords );
 		}
 
 
@@ -641,9 +641,9 @@ namespace Nez.UI
 		/// <param name="stageCoords">Stage coords.</param>
 		public Vector2 stageToScreenCoordinates( Vector2 stageCoords )
 		{
-			if( _camera == null )
+			if( camera == null )
 				return stageCoords;
-			return _camera.worldToScreenPoint( stageCoords );
+			return camera.worldToScreenPoint( stageCoords );
 		}
 
 


### PR DESCRIPTION
If the UI was being rendered by a ScreenSpaceRenderer and the scene had a different camera, then the ScissorStack would generate the clipping rectangle from the wrong camera.