### PR TITLE
Fix destroying entity not destroying all children

### DIFF
--- a/Nez-PCL/ECS/Entity.cs
+++ b/Nez-PCL/ECS/Entity.cs
@@ -192,7 +192,7 @@ namespace Nez
 			transform.parent = null;
 
 			// destroy any children we have
-			for( var i = 0; i < transform.childCount; i++ )
+			for( var i = transform.childCount - 1; i >= 0; i-- )
 			{
 				var child = transform.getChild( i );
 				child.entity.destroy();


### PR DESCRIPTION
`Entity.destroy()` indirectly modifies the child collection as it loops over it, which results in some children not being destroyed. One solution is to simply iterate over the list in reverse.