### PR TITLE
Fix TiledMap dimensions

### DIFF
--- a/Nez-PCL/PipelineRuntime/Tiled/TiledMap.cs
+++ b/Nez-PCL/PipelineRuntime/Tiled/TiledMap.cs
@@ -26,12 +26,12 @@ namespace Nez.Tiled
 
 		public int widthInPixels
 		{
-			get { return width * tileWidth - width; }       
+			get { return width * tileWidth; }
 		}
 
 		public int heightInPixels
 		{
-			get { return height * tileHeight - height; }
+			get { return height * tileHeight; }
 		}
 
 		internal int largestTileWidth;


### PR DESCRIPTION
There used to be a comment here that said

> annoyingly we have to compensate 1 pixel per tile, seems to be a bug in MonoGame?

but I don't see anything indicating that this is still the case. Just `tile count * tile dimension` is giving the expected behavior.