### PR TITLE
setTile instantiate generic type tile

### DIFF
--- a/Nez-PCL/PipelineRuntime/Tiled/TiledTile.cs
+++ b/Nez-PCL/PipelineRuntime/Tiled/TiledTile.cs
@@ -53,6 +53,8 @@ namespace Nez.Tiled
 		int? _tilesetTileIndex;
 
 
+        public TiledTile() { }
+
 		public TiledTile( int id )
 		{
 			this.id = id;

--- a/Nez-PCL/PipelineRuntime/Tiled/TiledTileLayer.cs
+++ b/Nez-PCL/PipelineRuntime/Tiled/TiledTileLayer.cs
@@ -181,31 +181,39 @@ namespace Nez.Tiled
 		/// <returns>The tile.</returns>
 		public TiledTile setTile( int x, int y, int tileId )
 		{
-			var tile = getTile( x, y );
-			if( tile == null )
-			{
-				tile = new TiledTile( tileId )
-				{
-					x = x,
-					y = y
-				};
-				tiles[x + y * width] = tile;
-			}
-			else
-			{
-				tile.setTileId( tileId );
-			}
-
-			tile.tileset = tiledMap.getTilesetForTileId( tileId );
-
-			return tile;
+            return setTile<TiledTile>( x, y, tileId );
 		}
 
-
-		public T setTile<T>( int x, int y, int tileId ) where T : TiledTile
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T">The type of tile to set(create).</typeparam>
+        /// <param name="x">The x coordinate.</param>
+        /// <param name="y">The y coordinate.</param>
+        /// <param name="tileId">the id to set the tile to.</param>
+        /// <returns>The tile.</returns>
+        public T setTile<T>( int x, int y, int tileId ) where T : TiledTile, new()
 		{
-			return setTile( x, y, tileId ) as T;
-		}
+            var tile = getTile<T>( x, y );
+            if ( tile == null || tile.GetType() != typeof( T ) )
+            {
+                tile = new T()
+                {
+                    id = tileId,
+                    x = x,
+                    y = y
+                };
+                tiles[ x + y * width ] = tile;
+            }
+            else
+            {
+                tile.setTileId( tileId );
+            }
+
+            tile.tileset = tiledMap.getTilesetForTileId( tileId );
+
+            return tile;
+        }
 
 
 		/// <summary>


### PR DESCRIPTION
Following the last merge it was no longer possible to extend the TiledLayer in such a way that it can use anything other than the TiledTile class for tile instances. (Virtual Function CreateTile was dropped).

Here's a better solution that should fit with the extendable nature of Nez.

- Modified TiledTile to accept a parameterless constructor, allowing for tiles to be instantiated based on generics  `setTile<SpecialTile>( x, y, tileId );`

- Modified TiledTileLayer `setTile<T>` signature to instantiate a T instance instead of a TiledTile instance