### PR TITLE
Tiled object helper property

### DIFF
--- a/Nez-PCL/PipelineRuntime/Tiled/TiledObject.cs
+++ b/Nez-PCL/PipelineRuntime/Tiled/TiledObject.cs
@@ -29,13 +29,13 @@ namespace Nez.Tiled
 		public string objectType;
 		public Vector2[] polyPoints;
 		public Dictionary<string,string> properties = new Dictionary<string,string>();
-        public Vector2 position
-        {
-            get { return new Vector2(x, y); }
-            set { x = (int)value.X; y = (int)value.Y; }
-        }
+	        public Vector2 position
+	        {
+	            get { return new Vector2(x, y); }
+	            set { x = (int)value.X; y = (int)value.Y; }
+	        }
 
-        public TiledObject()
+        	public TiledObject()
 		{}
 	}
 }

--- a/Nez-PCL/PipelineRuntime/Tiled/TiledObject.cs
+++ b/Nez-PCL/PipelineRuntime/Tiled/TiledObject.cs
@@ -29,9 +29,13 @@ namespace Nez.Tiled
 		public string objectType;
 		public Vector2[] polyPoints;
 		public Dictionary<string,string> properties = new Dictionary<string,string>();
+        public Vector2 position
+        {
+            get { return new Vector2(x, y); }
+            set { x = (int)value.X; y = (int)value.Y; }
+        }
 
-
-		public TiledObject()
+        public TiledObject()
 		{}
 	}
 }


### PR DESCRIPTION
I'm not sure if this jives with the philosophy for Nez, but I noticed when using a `TiledObject`, if I needed to make an entity I'd often do this - 

```
createEntity("name", new Vector2(tiledObj.X, tiledObj.Y));
```

I added a little property in the TiledObject class that adds position, so I can then easily type

```
createEntity("name", tiledObj.position);
```

Edit: Not sure what's going on with my tabs, Github keeps changing them on me :pensive:  In the edit view/Files changed window it looks fine but in the commits they're misaligned.  Sorry about that.