### PR TITLE
Added parallax helpers for the follow camera

### DIFF
--- a/Nez-PCL/ECS/Components/FollowCamera.cs
+++ b/Nez-PCL/ECS/Components/FollowCamera.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Microsoft.Xna.Framework;
-
+using System.Collections.Generic;
 
 namespace Nez
 {
@@ -45,6 +45,13 @@ namespace Nez
 		/// </summary>
 		public Vector2 mapSize;
 
+        private Vector2 _lastPosition;
+
+        /// <summary>
+        /// Contains a number of layers used for a parallax effect
+        /// </summary>
+        public List<ParallaxLayer> parallaxLayers = new List<ParallaxLayer>();
+
 		Entity _targetEntity;
 		Vector2 _desiredPositionDelta;
 		CameraStyle _cameraStyle;
@@ -82,6 +89,9 @@ namespace Nez
 
 		void IUpdatable.update()
 		{
+            // store our current position
+            _lastPosition = transform.position;
+
 			// translate the deadzone to be in world space
 			var halfScreen = entity.scene.sceneRenderTargetSize.ToVector2() * 0.5f;
 			_worldSpaceDeadzone.x = camera.position.X - halfScreen.X + deadzone.x + focusOffset.X;
@@ -100,6 +110,12 @@ namespace Nez
 				camera.position = clampToMapSize( camera.position );
 				camera.entity.transform.roundPosition();   
 			}
+
+            // loop through parallax layers and apply desired movement
+            foreach (var parallaxLayer in parallaxLayers)
+                foreach (var entity in parallaxLayer.entities)
+                    entity.transform.position += ((transform.position - _lastPosition) * parallaxLayer.parallaxFactor);
+                    
 		}
 
 

--- a/Nez-PCL/ECS/Components/ParallaxLayer.cs
+++ b/Nez-PCL/ECS/Components/ParallaxLayer.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+
+namespace Nez
+{
+    /// <summary>
+    /// Used with a FollowCamera in order to achieve a parallax effect.
+    /// </summary>
+    public class ParallaxLayer
+    {
+        /// <summary>
+        /// Contains every entity that should be affected by this layer.
+        /// </summary>
+        public List<Entity> entities { get; set; } = new List<Entity>();
+
+        /// <summary>
+        /// The amount of parallax to take into account.  A value of 0 is completely still, whereas a value of 1 moves in tandem with the FollowCamera
+        /// </summary>
+        public float parallaxFactor { get; set; }
+
+        /// <summary>
+        /// Initialize the ParallaxLayer
+        /// </summary>
+        /// <param name="ParallaxFactor">The amount of parallax to take into account.  Normal values from 0 - 1, where 1 is full movement, and 0 is completely still.</param>
+        /// <param name="Entities">The entities to initialize this layer with</param>
+        public ParallaxLayer(float ParallaxFactor, params Entity[] Entities)
+        {
+            parallaxFactor = ParallaxFactor;
+            entities.AddRange(Entities);
+        }
+    }
+}


### PR DESCRIPTION
Regarding issue #83, I think it would be helpful to have that functionality baked into the FollowCamera instead of having logic spread out between entities. 

I've added a few lines to the `FollowCamera` and a new `ParallaxLayer` class.  Cameras have a list of layers to which they can apply parallax.  Example usage:

```
var followCamera = camera.entity.addComponent<FollowCamera>(new FollowCamera(player));

// adds a new layer with 20% follow
followCamera.parallaxLayers.Add(new ParallaxLayer(0.2f, entity1, entity2, entity3, entity4));

// adds a new layer with 50% follow
followCamera.parallaxLayers.Add(new ParallaxLayer(0.5f, entity5, entity6));
```