### PR TITLE
Fix sprite animation not being prepared for use

### DIFF
--- a/Nez-PCL/ECS/Components/Renderables/Sprites/SpriteAnimation.cs
+++ b/Nez-PCL/ECS/Components/Renderables/Sprites/SpriteAnimation.cs
@@ -57,7 +57,7 @@ namespace Nez.Sprites
 		float _fps = 10;
 		bool _loop = true;
 		bool _pingPong = false;
-		bool _isDirty;
+		bool _isDirty = true;
 
 
 		public SpriteAnimation()


### PR DESCRIPTION
`_hasBeenPreparedForUse` was replaced with `_isDirty` and the checks in `prepareForUse()` were negated, but the initial value was not negated as well, causing the sprite animation to not be prepared for use.