### PR TITLE
Fix to errant selectBoxList closing

### DIFF
--- a/Nez-PCL/UI/Widgets/SelectBoxList.cs
+++ b/Nez-PCL/UI/Widgets/SelectBoxList.cs
@@ -146,7 +146,7 @@ namespace Nez.UI
 			{
 				var point = stage.getMousePosition();
 				point = screenToLocalCoordinates( point );
-				if( point.X < 0 || point.X > width || point.Y < -20 || point.Y > height + 20 )
+				if( point.X < 0 || point.X > width || point.Y < -height || point.Y > 0 )
 				{
 					// we are in draw here so we cant modify the hierarchy until the draw is complete
 					Core.schedule( 0f, t => hide() );


### PR DESCRIPTION
For taller SelectBoxes than ones that are created with the default skin (tested on 43 pixels tall), on its update the condition governing whether the list should hide again was fulfilled when it shouldn't have been, resulting in the SelectBox immediately hiding its list after opening if you clicked more than halfway up. On a 43-px tall one, that's pretty much the magic 20 that was here.

This behaviour doesn't appear with a dropdown having the default skin, and I suspect it's because it was shorter than 20 pixels.