### PR TITLE
Group x/y fix

### DIFF
--- a/Nez-PCL/UI/Base/Group.cs
+++ b/Nez-PCL/UI/Base/Group.cs
@@ -188,12 +188,11 @@ namespace Nez.UI
 					if( !children[i].isVisible() )
 						continue;
 					
-					float cx = children[i].x, cy = children[i].y;
-					children[i].x = cx + offsetX;
-					children[i].y = cy + offsetY;
+		                        children[i].x += offsetX;
+		                        children[i].y += offsetY;
 					children[i].draw( graphics, parentAlpha );
-					children[i].x = cx;
-					children[i].y = cy;
+					children[i].x -= offsetX;
+					children[i].y -= offsetY;
 				}
 				x = offsetX;
 				y = offsetY;
@@ -246,12 +245,11 @@ namespace Nez.UI
 					if( !children[i].getDebug() && !( children[i] is Group ) )
 						continue;
 
-					float cx = children[i].x, cy = children[i].y;
-					children[i].x = cx + offsetX;
-					children[i].y = cy + offsetY;
+					children[i].x += offsetX;
+					children[i].y += offsetY;
 					children[i].debugRender( graphics );
-					children[i].x = cx;
-					children[i].y = cy;
+					children[i].x -= offsetX;
+					children[i].y -= offsetY;
 				}
 				x = offsetX;
 				y = offsetY;


### PR DESCRIPTION
Groups could show unexpected behaviour if the x/y changed during the draw calls. This could be seen with two dropdowns side by side - click one dropdown to open it, and then next click the other dropdown, and the second list would be shown in the same place as the first was.
This change keeps any changes from draw calls, but still removes the offset. This seems to have resolved the issue.