### PR TITLE
Implement BestFit scene resolution policy

### DIFF
--- a/Nez-PCL/ECS/Scene.cs
+++ b/Nez-PCL/ECS/Scene.cs
@@ -60,7 +60,12 @@ namespace Nez
 			/// <summary>
 			/// Pixel perfect version of FixedWidth. Scaling is limited to integer values.
 			/// </summary>
-			FixedWidthPixelPerfect
+			FixedWidthPixelPerfect,
+			/// <summary>
+			/// The application takes the width and height that best fits the design resolution with optional
+			/// cropping inside of "bleed area" and possible letter/pillar boxing
+			/// </summary>
+			BestFit
 		}
 
 
@@ -160,6 +165,11 @@ namespace Nez
 		static Point defaultDesignResolutionSize;
 
 		/// <summary>
+		/// default bleed size for <see cref="SceneResolutionPolicy.BestFit"/> resolution policy
+		/// </summary>
+		static Point defaultDesignBleedSize;
+		
+		/// <summary>
 		/// default resolution policy used for all scenes
 		/// </summary>
 		static SceneResolutionPolicy defaultSceneResolutionPolicy = SceneResolutionPolicy.None;
@@ -173,6 +183,11 @@ namespace Nez
 		/// design resolution size used by the scene
 		/// </summary>
 		Point _designResolutionSize;
+
+		/// <summary>
+		/// bleed size for <see cref="SceneResolutionPolicy.BestFit"/> resolution policy
+		/// </summary>
+		Point _designBleedSize;
 
 		/// <summary>
 		/// this gets setup based on the resolution policy and is used for the final blit of the RenderTarget
@@ -195,12 +210,27 @@ namespace Nez
 		/// <param name="width">Width.</param>
 		/// <param name="height">Height.</param>
 		/// <param name="sceneResolutionPolicy">Scene resolution policy.</param>
-		public static void setDefaultDesignResolution( int width, int height, SceneResolutionPolicy sceneResolutionPolicy )
+		/// <param name="horizontalBleed">Horizontal bleed size. Used only if resolution policy is set to <see cref="SceneResolutionPolicy.BestFit"/>.</param>
+		/// <param name="verticalBleed">Vertical bleed size. Used only if resolution policy is set to <see cref="SceneResolutionPolicy.BestFit"/>.</param>
+		public static void setDefaultDesignResolution( int width, int height, SceneResolutionPolicy sceneResolutionPolicy, int horizontalBleed = 0, int verticalBleed = 0 )
 		{
 			defaultDesignResolutionSize = new Point( width, height );
 			defaultSceneResolutionPolicy = sceneResolutionPolicy;
+			if( defaultSceneResolutionPolicy == SceneResolutionPolicy.BestFit )
+			{
+				setDefaultDesignBleedSize( horizontalBleed, verticalBleed );
+			}
 		}
 
+		/// <summary>
+		/// sets the default bleed size for <see cref="SceneResolutionPolicy.BestFit"/> resolution policy
+		/// </summary>
+		/// <param name="horizontalBleed">Horizontal bleed size.</param>
+		/// <param name="verticalBleed">Vertical bleed size.</param>
+		public static void setDefaultDesignBleedSize( int horizontalBleed, int verticalBleed )
+		{
+			defaultDesignBleedSize = new Point( horizontalBleed, verticalBleed );
+		}
 
 		#region Scene creation helpers
 
@@ -281,6 +311,7 @@ namespace Nez
 			// setup our resolution policy. we'll commit it in begin
 			_resolutionPolicy = defaultSceneResolutionPolicy;
 			_designResolutionSize = defaultDesignResolutionSize;
+			_designBleedSize = defaultDesignBleedSize;
 
 			initialize();
 		}
@@ -497,13 +528,29 @@ namespace Nez
 		/// <param name="width">Width.</param>
 		/// <param name="height">Height.</param>
 		/// <param name="sceneResolutionPolicy">Scene resolution policy.</param>
-		public void setDesignResolution( int width, int height, SceneResolutionPolicy sceneResolutionPolicy )
+		/// <param name="horizontalBleed">Horizontal bleed size. Used only if resolution policy is set to <see cref="SceneResolutionPolicy.BestFit"/>.</param>
+		/// <param name="verticalBleed">Horizontal bleed size. Used only if resolution policy is set to <see cref="SceneResolutionPolicy.BestFit"/>.</param>
+		public void setDesignResolution( int width, int height, SceneResolutionPolicy sceneResolutionPolicy, int horizontalBleed = 0, int verticalBleed = 0 )
 		{
 			_designResolutionSize = new Point( width, height );
 			_resolutionPolicy = sceneResolutionPolicy;
+			if( _resolutionPolicy == SceneResolutionPolicy.BestFit )
+			{
+				setDesignBleedSize(horizontalBleed, verticalBleed);
+			}
 			updateResolutionScaler();
 		}
 
+		/// <summary>
+		/// sets the bleed size for <see cref="SceneResolutionPolicy.BestFit"/> resolution policy.
+		/// this method will not invoke <see cref="updateResolutionScaler"/> directly.
+		/// </summary>
+		/// <param name="horizontalBleed">Horizontal bleed size.</param>
+		/// <param name="verticalBleed">Vertical bleed size.</param>
+		public void setDesignBleedSize( int horizontalBleed, int verticalBleed )
+		{
+			_designBleedSize = new Point( horizontalBleed, verticalBleed );
+		}
 
 		void updateResolutionScaler()
 		{
@@ -637,6 +684,21 @@ namespace Nez
 					rectCalculated = true;
 
 					renderTargetHeight = (int)( designSize.Y * resolutionScaleY / pixelPerfectScale );
+
+					break;
+
+				case SceneResolutionPolicy.BestFit:
+
+					var safeScaleX = (float)screenSize.X / (designSize.X - _designBleedSize.X);
+					var safeScaleY = (float)screenSize.Y / (designSize.Y - _designBleedSize.Y);
+
+					float resolutionScale = MathHelper.Max(resolutionScaleX, resolutionScaleY);
+					float safeScale = MathHelper.Min(safeScaleX, safeScaleY);
+
+					resolutionScaleX = resolutionScaleY = MathHelper.Min(resolutionScale, safeScale);
+
+					renderTargetWidth = designSize.X;
+					renderTargetHeight = designSize.Y;
 
 					break;
 			}


### PR DESCRIPTION
This PR adds `SceneResolutionPolicy.BestFit` which works somewhat like `ShowAll` except that a "bleed area" can be defined where cropping will occur if necessary (if both horizontal and vertical bleed size is set to 0 then it behaves exactly as `ShowAll`).

Advantage of this resolution policy is that you can, for example, set you design size to 1348x900 and define bleed areas of 148x140 (so that's 74px from left and right, and 70px from top and bottom edge) and basically you cover 3:2, 16:10, 16:9, 4:3 and 5:3 resolutions without any pillar or letter boxing (and those are most common aspect-ratios in use today across all devices). You just have to keep all your interactive components inside of a safe area (so in this example that's 1200x760 rect in the center) and fill the "bleed area" with some filler content.

I found this to be the most useful way of handling scaling to different resolutions for the game I'm working on (a point and click adventure) so I though someone else might like it and I've decided to share it :)

Now, regarding the implementation, this resolution policy needs additional parameters (bleed size) so I'm not sure if adding `setDefaultDesignBleedSize`, `setDesignBleedSize` methods and extending `setDefaultDesignResolution` and `setDesignSize` to accept optional bleed parameters is the best choice. It looks a bit hackish to me :/ 
I have added this same functionality to the MonoGame.Extended and there these resolution policies (called viewport adapters there) are implemented via classes so the API looks very clean so maybe a similar API could be introduced for Nez too? 
I'm willing to contribute code which reimplements this API if changes like that are welcome :)