### PR TITLE
Fix filename conflicts with reserved keywords in the content generator template

### DIFF
--- a/T4Templates/ContentPathGenerator.tt
+++ b/T4Templates/ContentPathGenerator.tt
@@ -48,6 +48,16 @@ namespace Nez
 
 
 <#+
+	// C# reserved keywords
+	private System.Collections.Generic.HashSet<string>  keywords = new System.Collections.Generic.HashSet<string>
+	{
+		"abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked", "class", "const", "continue", "decimal", "default", "delegate",
+		"do", "double", "else", "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for", "foreach", "goto", "if", "implicit", "in",
+		"int", "interface", "internal", "is", "lock", "long", "namespace", "new", "null", "object", "operator", "out", "override", "params", "private",
+		"protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short", "sizeof", "stackalloc", "static", "string", "struct", "switch", "this",
+		"throw", "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual", "void", "volatile", "while"
+	};
+
 	// recursively creates a class for each directory
 	void printDirectoryClass( string dir, int depth, string sourceFolder )
 	{
@@ -83,6 +93,10 @@ namespace Nez
 
 			if( finalPath[0] == '/' || finalPath[0] == '\\' )
 				finalPath = finalPath.Substring( 1 );
+
+            //if file name is reserved insert a leading '@'
+			if(keywords.Contains(className))
+				className = className.Insert( 0, "@" );
 
 			WriteLine( "{0}public const string {1} = @\"{2}\";", firstIndent, className, finalPath );
 		}


### PR DESCRIPTION
* Add a HashSet of the reserved keywords in C#
* Insert a leading '@' for members that match reserved keywords