### PR TITLE
Fixed bounds not matching actual light area

### DIFF
--- a/Nez.Portable/Graphics/DeferredLighting/Lights/PointLight.cs
+++ b/Nez.Portable/Graphics/DeferredLighting/Lights/PointLight.cs
@@ -9,14 +9,24 @@ namespace Nez.DeferredLighting
 	/// </summary>
 	public class PointLight : DeferredLight
 	{
-		public override float width { get { return _radius * 2; } }
+        public override RectangleF bounds
+        {
+            get
+            {
+                if (_areBoundsDirty)
+                {
+                    _bounds.calculateBounds(entity.transform.position, _localOffset, _radius * entity.transform.scale, Vector2.One, 0, (_radius * entity.transform.scale.X) * 2f, (_radius * entity.transform.scale.Y) * 2f);
+                    _areBoundsDirty = false;
+                }
 
-		public override float height { get { return _radius * 2; } }
+                return _bounds;
+            }
+        }
 
-		/// <summary>
-		/// "height" above the scene in the z direction
-		/// </summary>
-		public float zPosition = 150f;
+        /// <summary>
+        /// "height" above the scene in the z direction
+        /// </summary>
+        public float zPosition = 150f;
 		
 		/// <summary>
 		/// how far does this light reaches


### PR DESCRIPTION
The bounding rectangle of the point light wasn't centred on the entity. Instead, it was anchored by the top-left corner. This caused lights to visibly turn on/off when the entity went in/out of the camera area.