### PR TITLE
Make TiledIsometricTiledLayer more component friendly

### DIFF
--- a/Nez.Portable/PipelineRuntime/Tiled/TiledIsometricTiledLayer.cs
+++ b/Nez.Portable/PipelineRuntime/Tiled/TiledIsometricTiledLayer.cs
@@ -98,67 +98,80 @@ namespace Nez.Tiled
 							continue;
 					}
 
-					// for the y position, we need to take into account if the tile is larger than the tileHeight and shift. Tiled uses
-					// a bottom-left coordinate system and MonoGame a top-left
-					var tx = tileworldpos.X + position.X;
-					var ty = tileworldpos.Y + position.Y;
-					var rotation = 0f;
-
-					var spriteEffects = SpriteEffects.None;
-					if( tile.flippedHorizonally )
-						spriteEffects |= SpriteEffects.FlipHorizontally;
-					if( tile.flippedVertically )
-						spriteEffects |= SpriteEffects.FlipVertically;
-					if( tile.flippedDiagonally )
-					{
-						if( tile.flippedHorizonally && tile.flippedVertically )
-						{
-							spriteEffects ^= SpriteEffects.FlipVertically;
-							rotation = MathHelper.PiOver2;
-							tx += tiledMap.tileHeight + ( tileRegion.sourceRect.Height - tiledMap.tileHeight );
-							ty -= ( tileRegion.sourceRect.Width - tiledMap.tileWidth );
-						}
-						else if( tile.flippedHorizonally )
-						{
-							spriteEffects ^= SpriteEffects.FlipVertically;
-							rotation = -MathHelper.PiOver2;
-							ty += tiledMap.tileHeight;
-						}
-						else if( tile.flippedVertically )
-						{
-							spriteEffects ^= SpriteEffects.FlipHorizontally;
-							rotation = MathHelper.PiOver2;
-							tx += tiledMap.tileWidth + ( tileRegion.sourceRect.Height - tiledMap.tileHeight );
-							ty += ( tiledMap.tileWidth - tileRegion.sourceRect.Width );
-						}
-						else
-						{
-							spriteEffects ^= SpriteEffects.FlipHorizontally;
-							rotation = -MathHelper.PiOver2;
-							ty += tiledMap.tileHeight;
-						}
-					}
-
-					// if we had no rotations (diagonal flipping) shift our y-coord to account for any non-tileSized tiles to account for
-					// Tiled being bottom-left origin
-					if( rotation == 0 )
-						ty += ( tiledMap.tileHeight - tileRegion.sourceRect.Height );
-
-					batcher.draw( tileRegion.texture2D, new Vector2( tx, ty ), tileRegion.sourceRect, color, rotation, Vector2.Zero, 1, spriteEffects, layerDepth );
+                    drawTile( batcher, position, layerDepth, x, y );
 				}
 			}
 		}
 
 
-		#region Tile management
+        public void drawTile(Batcher batcher, Vector2 position, float layerDepth, int x, int y)
+        {
+            var tile = getTile(x, y);
+            if (tile == null)
+                return;
 
-		/// <summary>
-		/// gets the TiledTile at the x/y coordinates. Note that these are tile coordinates not world coordinates!
-		/// </summary>
-		/// <returns>The tile.</returns>
-		/// <param name="x">The x coordinate.</param>
-		/// <param name="y">The y coordinate.</param>
-		public TiledTile getTile( int x, int y )
+            var tileworldpos = tiledMap.isometricTileToWorldPosition(x, y);
+            var tileRegion = tile.textureRegion;
+
+            // for the y position, we need to take into account if the tile is larger than the tileHeight and shift. Tiled uses
+            // a bottom-left coordinate system and MonoGame a top-left
+            var tx = tileworldpos.X + position.X;
+            var ty = tileworldpos.Y + position.Y;
+            var rotation = 0f;
+
+            var spriteEffects = SpriteEffects.None;
+            if (tile.flippedHorizonally)
+                spriteEffects |= SpriteEffects.FlipHorizontally;
+            if (tile.flippedVertically)
+                spriteEffects |= SpriteEffects.FlipVertically;
+            if (tile.flippedDiagonally)
+            {
+                if (tile.flippedHorizonally && tile.flippedVertically)
+                {
+                    spriteEffects ^= SpriteEffects.FlipVertically;
+                    rotation = MathHelper.PiOver2;
+                    tx += tiledMap.tileHeight + (tileRegion.sourceRect.Height - tiledMap.tileHeight);
+                    ty -= (tileRegion.sourceRect.Width - tiledMap.tileWidth);
+                }
+                else if (tile.flippedHorizonally)
+                {
+                    spriteEffects ^= SpriteEffects.FlipVertically;
+                    rotation = -MathHelper.PiOver2;
+                    ty += tiledMap.tileHeight;
+                }
+                else if (tile.flippedVertically)
+                {
+                    spriteEffects ^= SpriteEffects.FlipHorizontally;
+                    rotation = MathHelper.PiOver2;
+                    tx += tiledMap.tileWidth + (tileRegion.sourceRect.Height - tiledMap.tileHeight);
+                    ty += (tiledMap.tileWidth - tileRegion.sourceRect.Width);
+                }
+                else
+                {
+                    spriteEffects ^= SpriteEffects.FlipHorizontally;
+                    rotation = -MathHelper.PiOver2;
+                    ty += tiledMap.tileHeight;
+                }
+            }
+
+            // if we had no rotations (diagonal flipping) shift our y-coord to account for any non-tileSized tiles to account for
+            // Tiled being bottom-left origin
+            if (rotation == 0)
+                ty += (tiledMap.tileHeight - tileRegion.sourceRect.Height);
+
+            batcher.draw(tileRegion.texture2D, new Vector2(tx, ty), tileRegion.sourceRect, color, rotation, Vector2.Zero, 1, spriteEffects, layerDepth);
+        }
+
+
+        #region Tile management
+
+        /// <summary>
+        /// gets the TiledTile at the x/y coordinates. Note that these are tile coordinates not world coordinates!
+        /// </summary>
+        /// <returns>The tile.</returns>
+        /// <param name="x">The x coordinate.</param>
+        /// <param name="y">The y coordinate.</param>
+        public TiledTile getTile( int x, int y )
 		{
 			return tiles[x + y * width];
 		}


### PR DESCRIPTION
Through my own dev I found it pretty limiting that the entire layer->tile rendering occurs in a single method in the layer, as I wanted to calculate depth per tile without changing Nez. The solution I settled on is to split the individual tile rendering into a different method that external components can take advantage of.

The separate drawTile() method has no camera clipping or layer offset handling, leaving it up to the component to use its own implementation.