### PR TITLE
Update TiledMapImporter.cs

### DIFF
--- a/Nez.PipelineImporter/Tiled/TiledMapImporter.cs
+++ b/Nez.PipelineImporter/Tiled/TiledMapImporter.cs
@@ -41,7 +41,7 @@ namespace Nez.TiledMaps
 
 						var normExtTilesetPath = new DirectoryInfo( filePath ).FullName;
 						context.Logger.LogMessage( "Reading External Tileset File: " + normExtTilesetPath );
-						using( var file = new StreaReader( filePath ) )
+						using( var file = new StreamReader( filePath ) )
 						{
 							map.tilesets[i] = (TmxTileset)xmlSerializer.Deserialize( file );
 							map.tilesets[i].fixImagePath( filename, tileset.source );

--- a/Nez.PipelineImporter/Tiled/TiledMapImporter.cs
+++ b/Nez.PipelineImporter/Tiled/TiledMapImporter.cs
@@ -41,7 +41,7 @@ namespace Nez.TiledMaps
 
 						var normExtTilesetPath = new DirectoryInfo( filePath ).FullName;
 						context.Logger.LogMessage( "Reading External Tileset File: " + normExtTilesetPath );
-						using( var file = new FileStream( filePath, FileMode.Open ) )
+						using( var file = new StreaReader( filePath ) )
 						{
 							map.tilesets[i] = (TmxTileset)xmlSerializer.Deserialize( file );
 							map.tilesets[i].fixImagePath( filename, tileset.source );


### PR DESCRIPTION
Fixes issue with CS0433 Compile error in Visual Studio 2015, where both MonoGame and System.IO have FileMode defined.  Switching from FileStream() to StreamReader() solves issue.