### PR TITLE
Feature onTransitionCompleted()

### DIFF
--- a/Nez.Portable/Graphics/Transitions/SceneTransition.cs
+++ b/Nez.Portable/Graphics/Transitions/SceneTransition.cs
@@ -67,6 +67,11 @@ namespace Nez
 		/// </summary>
 		public Action onScreenObscured;
 
+        /// <summary>
+        /// called when the Transition has completed it's execution, so that other work can be called, such as Starting another transition.
+        /// </summary>
+        public Action onTransitionCompleted;
+
 		/// <summary>
 		/// flag indicating if this transition will load a new scene or not
 		/// </summary>
@@ -184,6 +189,9 @@ namespace Nez
 				previousSceneRender.Dispose();
 				previousSceneRender = null;
 			}
+
+            if (onTransitionCompleted != null)
+                onTransitionCompleted();
 		}
 
 


### PR DESCRIPTION
This is an Action, in which when a Transition has completed it's work, and cleaned up after itself, onTransitionCompleted() can be called, so that other work can be executed after the transition.  Such as creating a new transition to execute, this allows for Intro splash screens with multiple screens to be created.