### PR TITLE
NinePatch Padding handling

### DIFF
--- a/Nez.PipelineImporter/LibGdxAtlases/LibGdxAtlasWriter.cs
+++ b/Nez.PipelineImporter/LibGdxAtlases/LibGdxAtlasWriter.cs
@@ -52,6 +52,20 @@ namespace Nez.LibGdxAtlases
 							writer.Write( region.splits[3] );
 							LibGdxAtlasProcessor.logger.LogMessage( "Writing splits for region: {0}", region.name );
 						}
+
+                        if (region.pads == null)
+                        {
+                            writer.Write(false);
+                        }
+                        else
+                        {
+                            writer.Write(true);
+                            writer.Write(region.pads[0]);
+                            writer.Write(region.pads[1]);
+                            writer.Write(region.pads[2]);
+                            writer.Write(region.pads[3]);
+                            LibGdxAtlasProcessor.logger.LogMessage("Writing pads for region: {0}", region.name);
+                        }
 					}
 				}
 			}

--- a/Nez.Portable/Graphics/Textures/NinePatchSubtexture.cs
+++ b/Nez.Portable/Graphics/Textures/NinePatchSubtexture.cs
@@ -12,6 +12,10 @@ namespace Nez.Textures
 		public int top;
 		public int bottom;
 		public Rectangle[] ninePatchRects = new Rectangle[9];
+        public int? padLeft;
+        public int padRight;
+        public int padTop;
+        public int padBottom;
 
 
 		public NinePatchSubtexture( Texture2D texture, Rectangle sourceRect, int left, int right, int top, int bottom ) : base( texture, sourceRect )
@@ -20,6 +24,7 @@ namespace Nez.Textures
 			this.right = right;
 			this.top = top;
 			this.bottom = bottom;
+            this.padLeft = null;
 
 			generateNinePatchRects( sourceRect, ninePatchRects, left, right, top, bottom );
 		}

--- a/Nez.Portable/PipelineRuntime/LibGdxAtlases/LibGdxAtlasReader.cs
+++ b/Nez.Portable/PipelineRuntime/LibGdxAtlases/LibGdxAtlasReader.cs
@@ -33,12 +33,21 @@ namespace Nez.LibGdxAtlases
 					rect.Height = reader.ReadInt32();
 
 					var hasSplits = reader.ReadBoolean();
-					if( hasSplits )
-						subtextures[i] = new NinePatchSubtexture( texture, rect, reader.ReadInt32(), reader.ReadInt32(), reader.ReadInt32(), reader.ReadInt32() );
-					else
-						subtextures[i] = new Subtexture( texture, rect );
+                    if (hasSplits)
+                        subtextures[i] = new NinePatchSubtexture(texture, rect, reader.ReadInt32(), reader.ReadInt32(), reader.ReadInt32(), reader.ReadInt32());
+                    else
+                        subtextures[i] = new Subtexture(texture, rect);
 
-					regionNames[i] = name;
+                    var hasPads = reader.ReadBoolean();
+                    if (hasPads && hasSplits)
+                    {
+                        ((NinePatchSubtexture)subtextures[i]).padLeft = reader.ReadInt32();
+                        ((NinePatchSubtexture)subtextures[i]).padRight = reader.ReadInt32();
+                        ((NinePatchSubtexture)subtextures[i]).padTop = reader.ReadInt32();
+                        ((NinePatchSubtexture)subtextures[i]).padBottom = reader.ReadInt32();
+                    }
+
+                    regionNames[i] = name;
 				}
 
 				var atlas = new TextureAtlas( regionNames, subtextures );

--- a/Nez.Portable/UI/Drawable/NinePatchDrawable.cs
+++ b/Nez.Portable/UI/Drawable/NinePatchDrawable.cs
@@ -63,11 +63,22 @@ namespace Nez.UI
 			minWidth = _subtexture.ninePatchRects[MIDDLE_LEFT].Width + _subtexture.ninePatchRects[MIDDLE_CENTER].Width + _subtexture.ninePatchRects[MIDDLE_RIGHT].Width;
 			minHeight = _subtexture.ninePatchRects[TOP_CENTER].Height + _subtexture.ninePatchRects[MIDDLE_CENTER].Height + _subtexture.ninePatchRects[BOTTOM_CENTER].Height;
 
-			// by default, we will pad the content by the nine patch margins
-			leftWidth = _subtexture.left;
-			rightWidth = _subtexture.right;
-			topHeight = _subtexture.top;
-			bottomHeight = _subtexture.bottom;
+			// by default, if padding isn't given, we will pad the content by the nine patch margins
+            if (_subtexture.padLeft != null)
+            {
+                leftWidth = (float)_subtexture.padLeft;
+                rightWidth = _subtexture.padRight;
+                topHeight = _subtexture.padTop;
+                bottomHeight = _subtexture.padBottom;
+            }
+            else
+            {
+                leftWidth = _subtexture.left;
+                rightWidth = _subtexture.right;
+                topHeight = _subtexture.top;
+                bottomHeight = _subtexture.bottom;
+            }
+
 		}
 
 


### PR DESCRIPTION
Updated LibGdxAtlasWriter.cs to properly handle Writing out the Padding information to the .xnb file.
Updated LibGdxAtlasReader.cs to properly read the values out of the .xnb file
Updated NinePatchSubtexture.cs to handle Padding information, With padLeft being null, to determine if padding information is available.
Updated NinePatchDrawable.cs to properly use padding information if available, otherwise use the split as the padding information.

This patch confirmed to work, but requires that XNB Content to be re-compiled, as LibGdxAtlas content has been changed.