### PR TITLE
Fix Label preferred size is not calculated

### DIFF
--- a/Nez.Portable/UI/Widgets/Label.cs
+++ b/Nez.Portable/UI/Widgets/Label.cs
@@ -260,6 +260,11 @@ namespace Nez.UI
 
 		public override void layout()
 		{
+			if( _prefSizeInvalid )
+			{
+				computePrefSize();
+			}
+
 			var isWrapped = _wrapText && _ellipsis == null;
 			if( isWrapped )
 			{


### PR DESCRIPTION
When the Label instantiated with text or it's text set via `setText` method it marks as invalidated and it's `_wrappedString` field set null. But only part of the code which set's the `_wrappedString` other than `null` is `computePrefSize` method, which is only called in `preferredWidth` and `preferredHeight` getters, and only the `preferredHeight` getter is accessed in `layout()` method but only in if `setWrap` called. 