### PR TITLE
Add conversion of touch input positions to world coordinates

### DIFF
--- a/Nez.Portable/ECS/Camera.cs
+++ b/Nez.Portable/ECS/Camera.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Microsoft.Xna.Framework;
-
+#if !FNA
+using Microsoft.Xna.Framework.Input.Touch;
+#endif
 
 namespace Nez
 {
@@ -477,6 +479,17 @@ namespace Nez
 
 
 		/// <summary>
+		/// converts a point from screen coordinates to world
+		/// </summary>
+		/// <returns>The to world point.</returns>
+		/// <param name="screenPosition">Screen position.</param>
+		public Vector2 screenToWorldPoint(Point screenPosition)
+		{
+			return screenToWorldPoint(screenPosition.ToVector2());
+		}
+
+
+		/// <summary>
 		/// returns the mouse position in world space
 		/// </summary>
 		/// <returns>The to world point.</returns>
@@ -486,15 +499,16 @@ namespace Nez
 		}
 
 
+		#if !FNA
 		/// <summary>
-		/// converts a point from screen coordinates to world
+		/// returns the touch position in world space
 		/// </summary>
 		/// <returns>The to world point.</returns>
-		/// <param name="screenPosition">Screen position.</param>
-		public Vector2 screenToWorldPoint( Point screenPosition )
+		public Vector2 touchToWorldPoint(TouchLocation touch)
 		{
-			return screenToWorldPoint( screenPosition.ToVector2() );
+			return screenToWorldPoint( touch.scaledPosition() );
 		}
+		#endif
 
 		#endregion
 

--- a/Nez.Portable/Input/Input.cs
+++ b/Nez.Portable/Input/Input.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework.Input;
 using Microsoft.Xna.Framework;
 using System.Collections.Generic;
 using Nez.Systems;
+using System.Runtime.CompilerServices;
 #if !FNA
 using Microsoft.Xna.Framework.Input.Touch;
 #endif
@@ -22,7 +23,7 @@ namespace Nez
 		/// </summary>
 		internal static Vector2 _resolutionScale;
 		/// <summary>
-		/// set by the Scene and used to scale mouse input
+		/// set by the Scene and used to scale input
 		/// </summary>
 		internal static Point _resolutionOffset;
 		static KeyboardState _previousKbState;
@@ -80,6 +81,16 @@ namespace Nez
 				_virtualInputs.buffer[i].update();
 		}
 
+		/// <summary>
+		/// this takes into account the SceneResolutionPolicy and returns the value scaled to the RenderTargets coordinates
+		/// </summary>
+		/// <value>The scaled position.</value>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Vector2 scaledPosition(Vector2 position)
+		{
+			var scaledPos = new Vector2(position.X - _resolutionOffset.X, position.Y - _resolutionOffset.Y);
+			return scaledPos * _resolutionScale;
+		}
 
 		#region Keyboard
 
@@ -253,14 +264,7 @@ namespace Nez
 		/// this takes into account the SceneResolutionPolicy and returns the value scaled to the RenderTargets coordinates
 		/// </summary>
 		/// <value>The scaled mouse position.</value>
-		public static Vector2 scaledMousePosition
-		{
-			get
-			{
-				var mousePosition = new Vector2( _currentMouseState.X - _resolutionOffset.X, _currentMouseState.Y - _resolutionOffset.Y );
-				return mousePosition * _resolutionScale;
-			}
-		}
+		public static Vector2 scaledMousePosition { get { return scaledPosition(new Vector2(_currentMouseState.X, _currentMouseState.Y)); } }
 
 		public static Point mousePositionDelta
 		{

--- a/Nez.Portable/Input/Input.cs
+++ b/Nez.Portable/Input/Input.cs
@@ -92,6 +92,12 @@ namespace Nez
 			return scaledPos * _resolutionScale;
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Vector2 scaledPosition(Point position)
+		{
+			return scaledPosition(new Vector2(position.X, position.Y));
+		}
+
 		#region Keyboard
 
 		public static KeyboardState previousKeyboardState { get { return _previousKbState; } }

--- a/Nez.Portable/Input/TouchInputUtils.cs
+++ b/Nez.Portable/Input/TouchInputUtils.cs
@@ -1,0 +1,15 @@
+﻿#if !FNA
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input.Touch;
+
+namespace Nez
+{
+	public static class TouchInputUtils
+	{
+		public static Vector2 scaledPosition(this TouchLocation touchLocation)
+		{
+			return Input.scaledPosition( touchLocation.Position );
+		}
+	}
+}
+#endif


### PR DESCRIPTION
For discussion. Add support for projecting touch positions in to world space.

Extracts scaling algorithm in to a separate method in Input.
Adds scaledPosition method to TouchLocation (like scaledMousePosition).
Adds touchToWorldPoint method to Camera.

