### PR TITLE
Rename findObject to findComponent

### DIFF
--- a/Nez.Portable/ECS/InternalUtils/EntityList.cs
+++ b/Nez.Portable/ECS/InternalUtils/EntityList.cs
@@ -300,9 +300,9 @@ namespace Nez
 		/// <summary>
 		/// returns the first Component found in the Scene of type T
 		/// </summary>
-		/// <returns>The object of type.</returns>
+		/// <returns>The component of type.</returns>
 		/// <typeparam name="T">The 1st type parameter.</typeparam>
-		public T findObjectOfType<T>() where T : Component
+		public T findComponentOfType<T>() where T : Component
 		{
 			for( var i = 0; i < _entities.length; i++ )
 			{
@@ -332,9 +332,9 @@ namespace Nez
 		/// <summary>
 		/// returns all Components found in the Scene of type T. The returned List can be put back in the pool via ListPool.free.
 		/// </summary>
-		/// <returns>The objects of type.</returns>
+		/// <returns>The components of type.</returns>
 		/// <typeparam name="T">The 1st type parameter.</typeparam>
-		public List<T> findObjectsOfType<T>() where T : Component
+		public List<T> findComponentsOfType<T>() where T : Component
 		{
 			var comps = ListPool<T>.obtain();
 			for( var i = 0; i < _entities.length; i++ )

--- a/Nez.Portable/ECS/Scene.cs
+++ b/Nez.Portable/ECS/Scene.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Nez.Systems;
@@ -1066,24 +1066,24 @@ namespace Nez
 
 
 		/// <summary>
-		/// returns the first enabled loaded object of Type T
+		/// returns the first enabled loaded component of Type T
 		/// </summary>
-		/// <returns>The object of type.</returns>
+		/// <returns>The component of type.</returns>
 		/// <typeparam name="T">The 1st type parameter.</typeparam>
-		public T findObjectOfType<T>() where T : Component
+		public T findComponentOfType<T>() where T : Component
 		{
-			return entities.findObjectOfType<T>();
+			return entities.findComponentOfType<T>();
 		}
 
 
 		/// <summary>
-		/// returns a list of all enabled loaded objects of Type T
+		/// returns a list of all enabled loaded components of Type T
 		/// </summary>
-		/// <returns>The objects of type.</returns>
+		/// <returns>The components of type.</returns>
 		/// <typeparam name="T">The 1st type parameter.</typeparam>
-		public List<T> findObjectsOfType<T>() where T : Component
+		public List<T> findComponentsOfType<T>() where T : Component
 		{
-			return entities.findObjectsOfType<T>();
+			return entities.findComponentsOfType<T>();
 		}
 
 		#endregion

--- a/Nez.Portable/ECS/Scene.cs
+++ b/Nez.Portable/ECS/Scene.cs
@@ -1066,7 +1066,7 @@ namespace Nez
 
 
 		/// <summary>
-		/// Returns the first enabled loaded object of Type T
+		/// returns the first enabled loaded object of Type T
 		/// </summary>
 		/// <returns>The object of type.</returns>
 		/// <typeparam name="T">The 1st type parameter.</typeparam>
@@ -1077,7 +1077,7 @@ namespace Nez
 
 
 		/// <summary>
-		/// Returns a list of all enabled loaded objects of Type T
+		/// returns a list of all enabled loaded objects of Type T
 		/// </summary>
 		/// <returns>The objects of type.</returns>
 		/// <typeparam name="T">The 1st type parameter.</typeparam>
@@ -1105,7 +1105,7 @@ namespace Nez
 
 
 		/// <summary>
-		/// Removes an EntitySystem processor from the scene
+		/// removes an EntitySystem processor from the scene
 		/// </summary>
 		/// <param name="processor">Processor.</param>
 		public void removeEntityProcessor( EntitySystem processor )
@@ -1115,7 +1115,7 @@ namespace Nez
 
 
 		/// <summary>
-		/// Gets an EntitySystem processor
+		/// gets an EntitySystem processor
 		/// </summary>
 		/// <returns>The processor.</returns>
 		/// <typeparam name="T">The 1st type parameter.</typeparam>


### PR DESCRIPTION
Currently the naming of `Scene.findObjectOfType<T>` is a little ambiguous, since, compared to `Scene.findEntityOfType<T>` which checks for `T : Entity`, checks for `T: Component` instead. 