### PR TITLE
Add conversion of touch input positions to world coordinates for gestures

### DIFF
--- a/Nez.Portable/Nez.csproj
+++ b/Nez.Portable/Nez.csproj
@@ -571,6 +571,7 @@
     <Compile Include="Graphics\PostProcessing\PostProcessors\PolyLightPostProcessor.cs" />
     <Compile Include="ECS\Components\Renderables\PolygonLight\PolySpotLight.cs" />
     <Compile Include="Utils\Extensions\TouchLocationExt.cs" />
+    <Compile Include="Utils\Extensions\GestureSampleExt.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MonoGame.Framework">

--- a/Nez.Portable/Utils/Extensions/GestureSampleExt.cs
+++ b/Nez.Portable/Utils/Extensions/GestureSampleExt.cs
@@ -1,0 +1,21 @@
+﻿#if !FNA
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input.Touch;
+
+
+namespace Nez
+{
+	public static class GestureSampleExt
+	{
+		public static Vector2 scaledPosition( this GestureSample gestureSample )
+		{
+			return Input.scaledPosition( gestureSample.Position );
+		}
+
+		public static Vector2 scaledPosition2( this GestureSample gestureSample )
+		{
+			return Input.scaledPosition( gestureSample.Position2 );
+		}
+	}
+}
+#endif


### PR DESCRIPTION
Matches changes in  @9ea6a943772b38b66b912362a730b9ec85a2698e but for `GestureSample`

Adds `scaledPosition` and `scaledPosition2` extension methods.

