### PR TITLE
Disable input while scene transition is running

### DIFF
--- a/Nez.Portable/Input/Input.cs
+++ b/Nez.Portable/Input/Input.cs
@@ -65,6 +65,8 @@ namespace Nez
 
 		public static void update()
 		{
+			if (Core._instance._sceneTransition != null) return;
+			
 			touch.update();
 
 			_previousKbState = _currentKbState;


### PR DESCRIPTION
Sometimes i click too fast on a button to change scene when there is already a transition running so i get a weird error cause of the assert here: https://github.com/prime31/Nez/blob/master/Nez.Portable/Core.cs#L341

So i think input should be disabled if a transition is running