### PR TITLE
Adding getAllEntities and getAllComponents helper methods to EntityList and ComponentList

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ bld/
 # NuGet v3's project.json files produces more ignoreable files
 *.nuget.props
 *.nuget.targets
+*.ruleset

--- a/Nez.Portable/ECS/InternalUtils/ComponentList.cs
+++ b/Nez.Portable/ECS/InternalUtils/ComponentList.cs
@@ -51,29 +51,6 @@ namespace Nez
 
 		public Component this[int index] { get { return _components.buffer[index]; } }
 
-		/// <summary>
-		/// simple dump of all current components and components to be added, without requiring a type check
-		/// </summary>
-		/// <returns>all components</returns>
-		public Component[] toArray()
-		{
-			var components = ListPool<Component>.obtain();
-			getComponents(components);
-
-			for (var i = 0; i < _components.length; i++)
-			{
-				components.Add(_components.buffer[i]);
-			}
-
-			// we also check the pending components just in case addComponent and getComponent are called in the same frame
-			for (var i = 0; i < _componentsToAdd.Count; i++)
-			{
-				components.Add(_componentsToAdd[i]);
-			}
-
-			return components.ToArray();
-		}
-
 		#endregion
 
 
@@ -93,7 +70,7 @@ namespace Nez
 		{
 			Debug.warnIf( _componentsToRemove.Contains( component ), "You are trying to remove a Component ({0}) that you already removed", component );
 
-			// this may not be a live Component so we have to watch out for if it hasnt been processed yet but it is being removed in the same frame
+			// this may not be a live Component so we have to watch out for if it hasn't been processed yet but it is being removed in the same frame
 			if( _componentsToAdd.Contains( component ) )
 			{
 				_componentsToAdd.Remove( component );
@@ -276,6 +253,27 @@ namespace Nez
 			}
 
 			return null;
+		}
+
+
+		/// <summary>
+		/// Gets current components and components to be added, without requiring a type check. The returned List can be put back in the pool via ListPool.free.
+		/// </summary>
+		/// <returns>all components</returns>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public List<Component> getComponents()
+		{
+			var components = ListPool<Component>.obtain();
+			getComponents(components);
+
+			for (var i = 0; i < _components.length; i++)
+				components.Add(_components.buffer[i]);
+
+			// we also check the pending components just in case addComponent and getComponent are called in the same frame
+			for (var i = 0; i < _componentsToAdd.Count; i++)
+				components.Add(_componentsToAdd[i]);
+
+			return components;
 		}
 
 

--- a/Nez.Portable/ECS/InternalUtils/ComponentList.cs
+++ b/Nez.Portable/ECS/InternalUtils/ComponentList.cs
@@ -261,7 +261,7 @@ namespace Nez
 		/// </summary>
 		/// <returns>all components</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public List<Component> getComponents()
+		public List<Component> getAllComponents()
 		{
 			var components = ListPool<Component>.obtain();
 			getComponents(components);

--- a/Nez.Portable/ECS/InternalUtils/ComponentList.cs
+++ b/Nez.Portable/ECS/InternalUtils/ComponentList.cs
@@ -51,6 +51,29 @@ namespace Nez
 
 		public Component this[int index] { get { return _components.buffer[index]; } }
 
+		/// <summary>
+		/// simple dump of all current components and components to be added, without requiring a type check
+		/// </summary>
+		/// <returns>all components</returns>
+		public Component[] toArray()
+		{
+			var components = ListPool<Component>.obtain();
+			getComponents(components);
+
+			for (var i = 0; i < _components.length; i++)
+			{
+				components.Add(_components.buffer[i]);
+			}
+
+			// we also check the pending components just in case addComponent and getComponent are called in the same frame
+			for (var i = 0; i < _componentsToAdd.Count; i++)
+			{
+				components.Add(_componentsToAdd[i]);
+			}
+
+			return components.ToArray();
+		}
+
 		#endregion
 
 

--- a/Nez.Portable/ECS/InternalUtils/EntityList.cs
+++ b/Nez.Portable/ECS/InternalUtils/EntityList.cs
@@ -276,7 +276,7 @@ namespace Nez
 		/// gets current Entities and Entities to be added, without requiring a type check. The returned List can be put back in the pool via ListPool.free.
 		/// </summary>
 		/// <returns>all entities</returns>
-		public List<Entity> get()
+		public List<Entity> getAllEntities()
 		{
 			var list = ListPool<Entity>.obtain();
 			for (var i = 0; i < _entities.length; i++)

--- a/Nez.Portable/ECS/InternalUtils/EntityList.cs
+++ b/Nez.Portable/ECS/InternalUtils/EntityList.cs
@@ -378,4 +378,3 @@ namespace Nez
 
 	}
 }
-

--- a/Nez.Portable/ECS/InternalUtils/EntityList.cs
+++ b/Nez.Portable/ECS/InternalUtils/EntityList.cs
@@ -30,14 +30,14 @@ namespace Nez
 		/// <summary>
 		/// tracks entities by tag for easy retrieval
 		/// </summary>
-		Dictionary<int, List<Entity>> _entityDict = new Dictionary<int, List<Entity>>();
+		Dictionary<int,List<Entity>> _entityDict = new Dictionary<int, List<Entity>>();
 		List<int> _unsortedTags = new List<int>();
 
 		// used in updateLists to double buffer so that the original lists can be modified elsewhere
 		List<Entity> _tempEntityList = new List<Entity>();
 
 
-		public EntityList(Scene scene)
+		public EntityList( Scene scene )
 		{
 			this.scene = scene;
 		}
@@ -79,9 +79,9 @@ namespace Nez
 		}
 
 
-		internal void markTagUnsorted(int tag)
+		internal void markTagUnsorted( int tag )
 		{
-			_unsortedTags.Add(tag);
+			_unsortedTags.Add( tag );
 		}
 
 
@@ -89,9 +89,9 @@ namespace Nez
 		/// adds an Entity to the list. All lifecycle methods will be called in the next frame.
 		/// </summary>
 		/// <param name="entity">Entity.</param>
-		public void add(Entity entity)
+		public void add( Entity entity )
 		{
-			_entitiesToAdd.Add(entity);
+			_entitiesToAdd.Add( entity );
 		}
 
 
@@ -99,19 +99,19 @@ namespace Nez
 		/// removes an Entity from the list. All lifecycle methods will be called in the next frame.
 		/// </summary>
 		/// <param name="entity">Entity.</param>
-		public void remove(Entity entity)
+		public void remove( Entity entity )
 		{
-			Debug.warnIf(_entitiesToRemove.Contains(entity), "You are trying to remove an entity ({0}) that you already removed", entity.name);
+			Debug.warnIf( _entitiesToRemove.Contains( entity ), "You are trying to remove an entity ({0}) that you already removed", entity.name );
 
 			// guard against adding and then removing an Entity in the same frame
-			if (_entitiesToAdd.Contains(entity))
+			if( _entitiesToAdd.Contains( entity ) )
 			{
-				_entitiesToAdd.Remove(entity);
+				_entitiesToAdd.Remove( entity );
 				return;
 			}
 
-			if (!_entitiesToRemove.Contains(entity))
-				_entitiesToRemove.Add(entity);
+			if( !_entitiesToRemove.Contains( entity ) )
+				_entitiesToRemove.Add( entity );
 		}
 
 
@@ -129,7 +129,7 @@ namespace Nez
 			// be in the _entitiesToRemove list which will get handled by updateLists.
 			updateLists();
 
-			for (var i = 0; i < _entities.length; i++)
+			for( var i = 0; i < _entities.length; i++ )
 			{
 				_entities.buffer[i]._isDestroyed = true;
 				_entities.buffer[i].onRemovedFromScene();
@@ -145,35 +145,35 @@ namespace Nez
 		/// checks to see if the Entity is presently managed by this EntityList
 		/// </summary>
 		/// <param name="entity">Entity.</param>
-		public bool contains(Entity entity)
+		public bool contains( Entity entity )
 		{
-			return _entities.contains(entity) || _entitiesToAdd.Contains(entity);
+			return _entities.contains( entity ) || _entitiesToAdd.Contains( entity );
 		}
 
 
-		internal void addToTagList(Entity entity)
+		internal void addToTagList( Entity entity )
 		{
-			var list = entitiesWithTag(entity.tag);
-			Assert.isFalse(list.Contains(entity), "Entity tag list already contains this entity: {0}", entity);
+			var list = entitiesWithTag( entity.tag );
+			Assert.isFalse( list.Contains( entity ), "Entity tag list already contains this entity: {0}", entity );
 
-			list.Add(entity);
-			_unsortedTags.Add(entity.tag);
+			list.Add( entity );
+			_unsortedTags.Add( entity.tag );
 		}
 
 
-		internal void removeFromTagList(Entity entity)
+		internal void removeFromTagList( Entity entity )
 		{
-			_entityDict[entity.tag].Remove(entity);
+			_entityDict[entity.tag].Remove( entity );
 		}
 
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[MethodImpl( MethodImplOptions.AggressiveInlining )]
 		internal void update()
 		{
-			for (var i = 0; i < _entities.length; i++)
+			for( var i = 0; i < _entities.length; i++ )
 			{
 				var entity = _entities.buffer[i];
-				if (entity.enabled && (entity.updateInterval == 1 || Time.frameCount % entity.updateInterval == 0))
+				if( entity.enabled && ( entity.updateInterval == 1 || Time.frameCount % entity.updateInterval == 0 ) )
 					entity.update();
 			}
 		}
@@ -182,64 +182,64 @@ namespace Nez
 		public void updateLists()
 		{
 			// handle removals
-			if (_entitiesToRemove.Count > 0)
+			if( _entitiesToRemove.Count > 0 )
 			{
-				Utils.swap(ref _entitiesToRemove, ref _tempEntityList);
-				for (var i = 0; i < _tempEntityList.Count; i++)
+				Utils.swap( ref _entitiesToRemove, ref _tempEntityList );
+				for( var i = 0; i < _tempEntityList.Count; i++ )
 				{
 					var entity = _tempEntityList[i];
 
 					// handle the tagList
-					removeFromTagList(entity);
+					removeFromTagList( entity );
 
 					// handle the regular entity list
-					_entities.remove(entity);
+					_entities.remove( entity );
 					entity.onRemovedFromScene();
 					entity.scene = null;
 
-					if (Core.entitySystemsEnabled)
-						scene.entityProcessors.onEntityRemoved(entity);
+					if( Core.entitySystemsEnabled )
+						scene.entityProcessors.onEntityRemoved( entity );
 				}
 
 				_tempEntityList.Clear();
 			}
 
 			// handle additions
-			if (_entitiesToAdd.Count > 0)
+			if( _entitiesToAdd.Count > 0 )
 			{
-				Utils.swap(ref _entitiesToAdd, ref _tempEntityList);
-				for (var i = 0; i < _tempEntityList.Count; i++)
+				Utils.swap( ref _entitiesToAdd, ref _tempEntityList );
+				for( var i = 0; i < _tempEntityList.Count; i++ )
 				{
 					var entity = _tempEntityList[i];
 
-					_entities.add(entity);
+					_entities.add( entity );
 					entity.scene = scene;
 
 					// handle the tagList
-					addToTagList(entity);
+					addToTagList( entity );
 
-					if (Core.entitySystemsEnabled)
-						scene.entityProcessors.onEntityAdded(entity);
+					if( Core.entitySystemsEnabled )
+						scene.entityProcessors.onEntityAdded( entity );
 				}
 
 				// now that all entities are added to the scene, we loop through again and call onAddedToScene
-				for (var i = 0; i < _tempEntityList.Count; i++)
+				for( var i = 0; i < _tempEntityList.Count; i++ )
 					_tempEntityList[i].onAddedToScene();
 
 				_tempEntityList.Clear();
 				_isEntityListUnsorted = true;
 			}
 
-			if (_isEntityListUnsorted)
+			if( _isEntityListUnsorted )
 			{
 				_entities.sort();
 				_isEntityListUnsorted = false;
 			}
 
 			// sort our tagList if needed
-			if (_unsortedTags.Count > 0)
+			if( _unsortedTags.Count > 0 )
 			{
-				for (int i = 0, count = _unsortedTags.Count; i < count; i++)
+				for( int i = 0, count = _unsortedTags.Count; i < count; i++ )
 				{
 					var tag = _unsortedTags[i];
 					_entityDict[tag].Sort();
@@ -256,18 +256,18 @@ namespace Nez
 		/// </summary>
 		/// <returns>The entity.</returns>
 		/// <param name="name">Name.</param>
-		public Entity findEntity(string name)
+		public Entity findEntity( string name )
 		{
-			for (var i = 0; i < _entities.length; i++)
+			for( var i = 0; i < _entities.length; i++ )
 			{
-				if (_entities.buffer[i].name == name)
+				if( _entities.buffer[i].name == name )
 					return _entities.buffer[i];
 			}
 
 			// in case an entity is added and searched for in the same frame we check the toAdd list
-			for (var i = 0; i < _entitiesToAdd.Count; i++)
+			for( var i = 0; i < _entitiesToAdd.Count; i++ )
 			{
-				if (_entitiesToAdd[i].name == name)
+				if( _entitiesToAdd[i].name == name )
 					return _entitiesToAdd[i];
 			}
 
@@ -280,10 +280,10 @@ namespace Nez
 		/// </summary>
 		/// <returns>The with tag.</returns>
 		/// <param name="tag">Tag.</param>
-		public List<Entity> entitiesWithTag(int tag)
+		public List<Entity> entitiesWithTag( int tag )
 		{
 			List<Entity> list = null;
-			if (!_entityDict.TryGetValue(tag, out list))
+			if( !_entityDict.TryGetValue( tag, out list ) )
 			{
 				list = new List<Entity>();
 				_entityDict[tag] = list;
@@ -301,17 +301,17 @@ namespace Nez
 		public List<Entity> entitiesOfType<T>() where T : Entity
 		{
 			var list = ListPool<Entity>.obtain();
-			for (var i = 0; i < _entities.length; i++)
+			for( var i = 0; i < _entities.length; i++ )
 			{
-				if (_entities.buffer[i] is T)
-					list.Add(_entities.buffer[i]);
+				if( _entities.buffer[i] is T )
+					list.Add( _entities.buffer[i] );
 			}
 
 			// in case an entity is added and searched for in the same frame we check the toAdd list
-			for (var i = 0; i < _entitiesToAdd.Count; i++)
+			for( var i = 0; i < _entitiesToAdd.Count; i++ )
 			{
-				if (_entitiesToAdd[i] is T)
-					list.Add(_entitiesToAdd[i]);
+				if( _entitiesToAdd[i] is T )
+					list.Add( _entitiesToAdd[i] );
 			}
 
 			return list;
@@ -325,23 +325,23 @@ namespace Nez
 		/// <typeparam name="T">The 1st type parameter.</typeparam>
 		public T findComponentOfType<T>() where T : Component
 		{
-			for (var i = 0; i < _entities.length; i++)
+			for( var i = 0; i < _entities.length; i++ )
 			{
-				if (_entities.buffer[i].enabled)
+				if( _entities.buffer[i].enabled )
 				{
 					var comp = _entities.buffer[i].getComponent<T>();
-					if (comp != null)
+					if( comp != null )
 						return comp;
 				}
 			}
 
 			// in case an entity is added and searched for in the same frame we check the toAdd list
-			for (var i = 0; i < _entitiesToAdd.Count; i++)
+			for( var i = 0; i < _entitiesToAdd.Count; i++ )
 			{
-				if (_entitiesToAdd[i].enabled)
+				if( _entitiesToAdd[i].enabled )
 				{
 					var comp = _entitiesToAdd[i].getComponent<T>();
-					if (comp != null)
+					if( comp != null )
 						return comp;
 				}
 			}
@@ -358,17 +358,17 @@ namespace Nez
 		public List<T> findComponentsOfType<T>() where T : Component
 		{
 			var comps = ListPool<T>.obtain();
-			for (var i = 0; i < _entities.length; i++)
+			for( var i = 0; i < _entities.length; i++ )
 			{
-				if (_entities.buffer[i].enabled)
-					_entities.buffer[i].getComponents<T>(comps);
+				if( _entities.buffer[i].enabled )
+					_entities.buffer[i].getComponents<T>( comps );
 			}
 
 			// in case an entity is added and searched for in the same frame we check the toAdd list
-			for (var i = 0; i < _entitiesToAdd.Count; i++)
+			for( var i = 0; i < _entitiesToAdd.Count; i++ )
 			{
-				if (_entitiesToAdd[i].enabled)
-					_entitiesToAdd[i].getComponents<T>(comps);
+				if( _entitiesToAdd[i].enabled )
+					_entitiesToAdd[i].getComponents<T>( comps );
 			}
 
 			return comps;

--- a/Nez.Portable/ECS/InternalUtils/EntityList.cs
+++ b/Nez.Portable/ECS/InternalUtils/EntityList.cs
@@ -49,27 +49,6 @@ namespace Nez
 
 		public Entity this[int index] { get { return _entities.buffer[index]; } }
 
-		/// <summary>
-		/// simple dump of all current entities and entities to be added, without requiring a type check
-		/// </summary>
-		/// <returns>all entities</returns>
-		public Entity[] toArray()
-		{
-			var list = ListPool<Entity>.obtain();
-			for (var i = 0; i < _entities.length; i++)
-			{
-				list.Add(_entities.buffer[i]);
-			}
-
-			// in case an entity is added and searched for in the same frame we check the toAdd list
-			for (var i = 0; i < _entitiesToAdd.Count; i++)
-			{
-				list.Add(_entitiesToAdd[i]);
-			}
-
-			return list.ToArray();
-		}
-
 		#endregion
 
 
@@ -290,6 +269,24 @@ namespace Nez
 			}
 
 			return _entityDict[tag];
+		}
+
+
+		/// <summary>
+		/// gets current Entities and Entities to be added, without requiring a type check. The returned List can be put back in the pool via ListPool.free.
+		/// </summary>
+		/// <returns>all entities</returns>
+		public List<Entity> get()
+		{
+			var list = ListPool<Entity>.obtain();
+			for (var i = 0; i < _entities.length; i++)
+				list.Add(_entities.buffer[i]);
+		
+			// in case an entity is added and searched for in the same frame we check the toAdd list
+			for (var i = 0; i < _entitiesToAdd.Count; i++)
+				list.Add(_entitiesToAdd[i]);
+		
+			return list;
 		}
 
 

--- a/Nez.Portable/ECS/InternalUtils/EntityList.cs
+++ b/Nez.Portable/ECS/InternalUtils/EntityList.cs
@@ -30,14 +30,14 @@ namespace Nez
 		/// <summary>
 		/// tracks entities by tag for easy retrieval
 		/// </summary>
-		Dictionary<int,List<Entity>> _entityDict = new Dictionary<int, List<Entity>>();
+		Dictionary<int, List<Entity>> _entityDict = new Dictionary<int, List<Entity>>();
 		List<int> _unsortedTags = new List<int>();
 
 		// used in updateLists to double buffer so that the original lists can be modified elsewhere
 		List<Entity> _tempEntityList = new List<Entity>();
 
 
-		public EntityList( Scene scene )
+		public EntityList(Scene scene)
 		{
 			this.scene = scene;
 		}
@@ -49,6 +49,27 @@ namespace Nez
 
 		public Entity this[int index] { get { return _entities.buffer[index]; } }
 
+		/// <summary>
+		/// simple dump of all current entities and entities to be added, without requiring a type check
+		/// </summary>
+		/// <returns>all entities</returns>
+		public Entity[] toArray()
+		{
+			var list = ListPool<Entity>.obtain();
+			for (var i = 0; i < _entities.length; i++)
+			{
+				list.Add(_entities.buffer[i]);
+			}
+
+			// in case an entity is added and searched for in the same frame we check the toAdd list
+			for (var i = 0; i < _entitiesToAdd.Count; i++)
+			{
+				list.Add(_entitiesToAdd[i]);
+			}
+
+			return list.ToArray();
+		}
+
 		#endregion
 
 
@@ -58,9 +79,9 @@ namespace Nez
 		}
 
 
-		internal void markTagUnsorted( int tag )
+		internal void markTagUnsorted(int tag)
 		{
-			_unsortedTags.Add( tag );
+			_unsortedTags.Add(tag);
 		}
 
 
@@ -68,9 +89,9 @@ namespace Nez
 		/// adds an Entity to the list. All lifecycle methods will be called in the next frame.
 		/// </summary>
 		/// <param name="entity">Entity.</param>
-		public void add( Entity entity )
+		public void add(Entity entity)
 		{
-			_entitiesToAdd.Add( entity );
+			_entitiesToAdd.Add(entity);
 		}
 
 
@@ -78,19 +99,19 @@ namespace Nez
 		/// removes an Entity from the list. All lifecycle methods will be called in the next frame.
 		/// </summary>
 		/// <param name="entity">Entity.</param>
-		public void remove( Entity entity )
+		public void remove(Entity entity)
 		{
-			Debug.warnIf( _entitiesToRemove.Contains( entity ), "You are trying to remove an entity ({0}) that you already removed", entity.name );
+			Debug.warnIf(_entitiesToRemove.Contains(entity), "You are trying to remove an entity ({0}) that you already removed", entity.name);
 
 			// guard against adding and then removing an Entity in the same frame
-			if( _entitiesToAdd.Contains( entity ) )
+			if (_entitiesToAdd.Contains(entity))
 			{
-				_entitiesToAdd.Remove( entity );
+				_entitiesToAdd.Remove(entity);
 				return;
 			}
 
-			if( !_entitiesToRemove.Contains( entity ) )
-				_entitiesToRemove.Add( entity );
+			if (!_entitiesToRemove.Contains(entity))
+				_entitiesToRemove.Add(entity);
 		}
 
 
@@ -99,7 +120,7 @@ namespace Nez
 		/// </summary>
 		public void removeAllEntities()
 		{
-			// clear lists we dont need anymore
+			// clear lists we don't need anymore
 			_unsortedTags.Clear();
 			_entitiesToAdd.Clear();
 			_isEntityListUnsorted = false;
@@ -108,7 +129,7 @@ namespace Nez
 			// be in the _entitiesToRemove list which will get handled by updateLists.
 			updateLists();
 
-			for( var i = 0; i < _entities.length; i++ )
+			for (var i = 0; i < _entities.length; i++)
 			{
 				_entities.buffer[i]._isDestroyed = true;
 				_entities.buffer[i].onRemovedFromScene();
@@ -124,35 +145,35 @@ namespace Nez
 		/// checks to see if the Entity is presently managed by this EntityList
 		/// </summary>
 		/// <param name="entity">Entity.</param>
-		public bool contains( Entity entity )
+		public bool contains(Entity entity)
 		{
-			return _entities.contains( entity ) || _entitiesToAdd.Contains( entity );
+			return _entities.contains(entity) || _entitiesToAdd.Contains(entity);
 		}
 
 
-		internal void addToTagList( Entity entity )
+		internal void addToTagList(Entity entity)
 		{
-			var list = entitiesWithTag( entity.tag );
-			Assert.isFalse( list.Contains( entity ), "Entity tag list already contains this entity: {0}", entity );
+			var list = entitiesWithTag(entity.tag);
+			Assert.isFalse(list.Contains(entity), "Entity tag list already contains this entity: {0}", entity);
 
-			list.Add( entity );
-			_unsortedTags.Add( entity.tag );
+			list.Add(entity);
+			_unsortedTags.Add(entity.tag);
 		}
 
 
-		internal void removeFromTagList( Entity entity )
+		internal void removeFromTagList(Entity entity)
 		{
-			_entityDict[entity.tag].Remove( entity );
+			_entityDict[entity.tag].Remove(entity);
 		}
 
 
-		[MethodImpl( MethodImplOptions.AggressiveInlining )]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal void update()
 		{
-			for( var i = 0; i < _entities.length; i++ )
+			for (var i = 0; i < _entities.length; i++)
 			{
 				var entity = _entities.buffer[i];
-				if( entity.enabled && ( entity.updateInterval == 1 || Time.frameCount % entity.updateInterval == 0 ) )
+				if (entity.enabled && (entity.updateInterval == 1 || Time.frameCount % entity.updateInterval == 0))
 					entity.update();
 			}
 		}
@@ -161,64 +182,64 @@ namespace Nez
 		public void updateLists()
 		{
 			// handle removals
-			if( _entitiesToRemove.Count > 0 )
+			if (_entitiesToRemove.Count > 0)
 			{
-				Utils.swap( ref _entitiesToRemove, ref _tempEntityList );
-				for( var i = 0; i < _tempEntityList.Count; i++ )
+				Utils.swap(ref _entitiesToRemove, ref _tempEntityList);
+				for (var i = 0; i < _tempEntityList.Count; i++)
 				{
 					var entity = _tempEntityList[i];
 
 					// handle the tagList
-					removeFromTagList( entity );
+					removeFromTagList(entity);
 
 					// handle the regular entity list
-					_entities.remove( entity );
+					_entities.remove(entity);
 					entity.onRemovedFromScene();
 					entity.scene = null;
 
-					if( Core.entitySystemsEnabled )
-						scene.entityProcessors.onEntityRemoved( entity );
+					if (Core.entitySystemsEnabled)
+						scene.entityProcessors.onEntityRemoved(entity);
 				}
 
 				_tempEntityList.Clear();
 			}
 
 			// handle additions
-			if( _entitiesToAdd.Count > 0 )
+			if (_entitiesToAdd.Count > 0)
 			{
-				Utils.swap( ref _entitiesToAdd, ref _tempEntityList );
-				for( var i = 0; i < _tempEntityList.Count; i++ )
+				Utils.swap(ref _entitiesToAdd, ref _tempEntityList);
+				for (var i = 0; i < _tempEntityList.Count; i++)
 				{
 					var entity = _tempEntityList[i];
 
-					_entities.add( entity );
+					_entities.add(entity);
 					entity.scene = scene;
 
 					// handle the tagList
-					addToTagList( entity );
+					addToTagList(entity);
 
-					if( Core.entitySystemsEnabled )
-						scene.entityProcessors.onEntityAdded( entity );
+					if (Core.entitySystemsEnabled)
+						scene.entityProcessors.onEntityAdded(entity);
 				}
 
 				// now that all entities are added to the scene, we loop through again and call onAddedToScene
-				for( var i = 0; i < _tempEntityList.Count; i++ )
+				for (var i = 0; i < _tempEntityList.Count; i++)
 					_tempEntityList[i].onAddedToScene();
 
 				_tempEntityList.Clear();
 				_isEntityListUnsorted = true;
 			}
 
-			if( _isEntityListUnsorted )
+			if (_isEntityListUnsorted)
 			{
 				_entities.sort();
 				_isEntityListUnsorted = false;
 			}
 
 			// sort our tagList if needed
-			if( _unsortedTags.Count > 0 )
+			if (_unsortedTags.Count > 0)
 			{
-				for( int i = 0, count = _unsortedTags.Count; i < count; i++ )
+				for (int i = 0, count = _unsortedTags.Count; i < count; i++)
 				{
 					var tag = _unsortedTags[i];
 					_entityDict[tag].Sort();
@@ -235,18 +256,18 @@ namespace Nez
 		/// </summary>
 		/// <returns>The entity.</returns>
 		/// <param name="name">Name.</param>
-		public Entity findEntity( string name )
+		public Entity findEntity(string name)
 		{
-			for( var i = 0; i < _entities.length; i++ )
+			for (var i = 0; i < _entities.length; i++)
 			{
-				if( _entities.buffer[i].name == name )
+				if (_entities.buffer[i].name == name)
 					return _entities.buffer[i];
 			}
 
 			// in case an entity is added and searched for in the same frame we check the toAdd list
-			for( var i = 0; i < _entitiesToAdd.Count; i++ )
+			for (var i = 0; i < _entitiesToAdd.Count; i++)
 			{
-				if( _entitiesToAdd[i].name == name )
+				if (_entitiesToAdd[i].name == name)
 					return _entitiesToAdd[i];
 			}
 
@@ -259,10 +280,10 @@ namespace Nez
 		/// </summary>
 		/// <returns>The with tag.</returns>
 		/// <param name="tag">Tag.</param>
-		public List<Entity> entitiesWithTag( int tag )
+		public List<Entity> entitiesWithTag(int tag)
 		{
 			List<Entity> list = null;
-			if( !_entityDict.TryGetValue( tag, out list ) )
+			if (!_entityDict.TryGetValue(tag, out list))
 			{
 				list = new List<Entity>();
 				_entityDict[tag] = list;
@@ -280,17 +301,17 @@ namespace Nez
 		public List<Entity> entitiesOfType<T>() where T : Entity
 		{
 			var list = ListPool<Entity>.obtain();
-			for( var i = 0; i < _entities.length; i++ )
+			for (var i = 0; i < _entities.length; i++)
 			{
-				if( _entities.buffer[i] is T )
-					list.Add( _entities.buffer[i] );
+				if (_entities.buffer[i] is T)
+					list.Add(_entities.buffer[i]);
 			}
 
 			// in case an entity is added and searched for in the same frame we check the toAdd list
-			for( var i = 0; i < _entitiesToAdd.Count; i++ )
+			for (var i = 0; i < _entitiesToAdd.Count; i++)
 			{
-				if( _entitiesToAdd[i] is T )
-					list.Add( _entitiesToAdd[i] );
+				if (_entitiesToAdd[i] is T)
+					list.Add(_entitiesToAdd[i]);
 			}
 
 			return list;
@@ -298,29 +319,29 @@ namespace Nez
 
 
 		/// <summary>
-		/// returns the first Component found in the Scene of type T
+		/// returns the first enabled Component found in the Scene of type T
 		/// </summary>
 		/// <returns>The component of type.</returns>
 		/// <typeparam name="T">The 1st type parameter.</typeparam>
 		public T findComponentOfType<T>() where T : Component
 		{
-			for( var i = 0; i < _entities.length; i++ )
+			for (var i = 0; i < _entities.length; i++)
 			{
-				if( _entities.buffer[i].enabled )
+				if (_entities.buffer[i].enabled)
 				{
 					var comp = _entities.buffer[i].getComponent<T>();
-					if( comp != null )
+					if (comp != null)
 						return comp;
 				}
 			}
 
 			// in case an entity is added and searched for in the same frame we check the toAdd list
-			for( var i = 0; i < _entitiesToAdd.Count; i++ )
+			for (var i = 0; i < _entitiesToAdd.Count; i++)
 			{
-				if( _entitiesToAdd[i].enabled )
+				if (_entitiesToAdd[i].enabled)
 				{
 					var comp = _entitiesToAdd[i].getComponent<T>();
-					if( comp != null )
+					if (comp != null)
 						return comp;
 				}
 			}
@@ -330,24 +351,24 @@ namespace Nez
 
 
 		/// <summary>
-		/// returns all Components found in the Scene of type T. The returned List can be put back in the pool via ListPool.free.
+		/// returns all enabled Components found in the Scene of type T. The returned List can be put back in the pool via ListPool.free.
 		/// </summary>
 		/// <returns>The components of type.</returns>
 		/// <typeparam name="T">The 1st type parameter.</typeparam>
 		public List<T> findComponentsOfType<T>() where T : Component
 		{
 			var comps = ListPool<T>.obtain();
-			for( var i = 0; i < _entities.length; i++ )
+			for (var i = 0; i < _entities.length; i++)
 			{
-				if( _entities.buffer[i].enabled )
-					_entities.buffer[i].getComponents<T>( comps );
+				if (_entities.buffer[i].enabled)
+					_entities.buffer[i].getComponents<T>(comps);
 			}
 
 			// in case an entity is added and searched for in the same frame we check the toAdd list
-			for( var i = 0; i < _entitiesToAdd.Count; i++ )
+			for (var i = 0; i < _entitiesToAdd.Count; i++)
 			{
-				if( _entitiesToAdd[i].enabled )
-					_entitiesToAdd[i].getComponents<T>( comps );
+				if (_entitiesToAdd[i].enabled)
+					_entitiesToAdd[i].getComponents<T>(comps);
 			}
 
 			return comps;

--- a/Nez.Portable/Utils/ListPool.cs
+++ b/Nez.Portable/Utils/ListPool.cs
@@ -8,32 +8,32 @@ namespace Nez
 	/// </summary>
 	public static class ListPool<T>
 	{
-		static readonly Queue<List<T>> _objectQueue = new Queue<List<T>>();
+		static readonly Queue<List<T>> _listQueue = new Queue<List<T>>();
 
 
 		/// <summary>
-		/// warms up the cache filling it with a max of cacheCount objects
+		/// warms up the cache filling it with a max of cacheCount lists
 		/// </summary>
 		/// <param name="cacheCount">new cache count</param>
 		public static void warmCache( int cacheCount )
 		{
-			cacheCount -= _objectQueue.Count;
+			cacheCount -= _listQueue.Count;
 			if( cacheCount > 0 )
 			{
 				for( var i = 0; i < cacheCount; i++ )
-					_objectQueue.Enqueue( new List<T>() );
+					_listQueue.Enqueue( new List<T>() );
 			}
 		}
 
 
 		/// <summary>
-		/// trims the cache down to cacheCount items
+		/// trims the cache down to cacheCount lists
 		/// </summary>
 		/// <param name="cacheCount">Cache count.</param>
 		public static void trimCache( int cacheCount )
 		{
-			while( cacheCount > _objectQueue.Count )
-				_objectQueue.Dequeue();
+			while( cacheCount > _listQueue.Count )
+				_listQueue.Dequeue();
 		}
 
 
@@ -42,30 +42,30 @@ namespace Nez
 		/// </summary>
 		public static void clearCache()
 		{
-			_objectQueue.Clear();
+			_listQueue.Clear();
 		}
 
 
 		/// <summary>
-		/// pops an item off the stack if available creating a new item as necessary
+		/// pops a list off the stack if available creating a new list as necessary
 		/// </summary>
 		public static List<T> obtain()
 		{
-			if( _objectQueue.Count > 0 )
-				return _objectQueue.Dequeue();
+			if( _listQueue.Count > 0 )
+				return _listQueue.Dequeue();
 
 			return new List<T>();
 		}
 
 
 		/// <summary>
-		/// pushes an item back on the stack
+		/// pushes an list back on the stack
 		/// </summary>
-		/// <param name="obj">Object.</param>
-		public static void free( List<T> obj )
+		/// <param name="list">List.</param>
+		public static void free( List<T> list )
 		{
-			_objectQueue.Enqueue( obj );
-			obj.Clear();
+			_listQueue.Enqueue( list );
+			list.Clear();
 		}
 	}
 }


### PR DESCRIPTION
There have been a number of times when I just wanted all the entities or components, mainly for serializing to disk, and having to do `entitiesOfType<Entity>()`, for example, seemed like a bunch of unnecessary type checking.

I also thought about changing `entitiesOfType<T>()` to use the new method like this, `return toArray().OfType<T>().Cast<Entity>().ToList();` but assume that's going to be slower than what you have already.

Clarified a couple summary comments that bit me early on.

And sorry about the multiple commits, I accidentally reformatted one of the files so I had to fix it.