### PR TITLE
fix #211: do not throw exception on hash key overflow

### DIFF
--- a/Nez.Portable/Physics/SpatialHash.cs
+++ b/Nez.Portable/Physics/SpatialHash.cs
@@ -465,7 +465,7 @@ namespace Nez.Spatial
 		[MethodImpl( MethodImplOptions.AggressiveInlining )]
 		long getKey( int x, int y )
 		{
-			return (long)x << 32 | (long)(uint)y;
+			return unchecked((long)x << 32 | (uint)y);
 		}
 
 


### PR DESCRIPTION
This allowed me to use the "check overflow" functionality for debug builds. There may be more of these issues, though. See #211.

Also took me an embarrassingly long time to prepare this PR. I'm not used to working with either GitHub or git. :disappointed: 