### PR TITLE
Fixed TextField rendering position

### DIFF
--- a/Nez.Portable/UI/Widgets/TextField.cs
+++ b/Nez.Portable/UI/Widgets/TextField.cs
@@ -587,7 +587,7 @@ namespace Nez.UI
 			}
 
 			var textY = getTextY( font, background );
-			var yOffset = (textY < 0) ? Height / 2 + textY /2 : 0;
+			var yOffset = (textY < 0) ? -textY - font.lineHeight/2 + preferredWidth / 2  : 0;
 			calculateOffsets();
 
 			if( _isFocused && hasSelection && selection != null )

--- a/Nez.Portable/UI/Widgets/TextField.cs
+++ b/Nez.Portable/UI/Widgets/TextField.cs
@@ -587,13 +587,12 @@ namespace Nez.UI
 			}
 
 			var textY = getTextY( font, background );
+			var yOffset = (textY < 0) ? Height / 2 + textY /2 : 0;
 			calculateOffsets();
 
 			if( _isFocused && hasSelection && selection != null )
-				drawSelection( selection, graphics, font, x + bgLeftWidth, y + textY );
+				drawSelection( selection, graphics, font, x + bgLeftWidth, y + textY + yOffset );
 
-			//float yOffset = font.isFlipped() ? -textHeight : 0;
-			float yOffset = 0;
 			if( displayText.Length == 0 )
 			{
 				if( !_isFocused && messageText != null )
@@ -616,7 +615,7 @@ namespace Nez.UI
 			{
 				blink();
 				if( cursorOn && style.cursor != null )
-					drawCursor( style.cursor, graphics, font, x + bgLeftWidth, y + textY );
+					drawCursor( style.cursor, graphics, font, x + bgLeftWidth, y + textY + yOffset );
 			}
 		}
 


### PR DESCRIPTION
For the moment if we increase the Height of the TextField, it'll render the text/selection/cursor at the very top, it is not the right behavior for a TextField (probably for a TextArea)

This commit fix the rendering position, if the height of the widget is larger than the height of the text, it'll apply an yOffset

Before:
![realm client_2017-04-19_01-24-34](https://cloud.githubusercontent.com/assets/27389256/25157033/fb0a6458-249e-11e7-8375-2aec726eb5f6.png)

After:
![realm client_2017-04-19_01-24-14](https://cloud.githubusercontent.com/assets/27389256/25157034/feb2e90e-249e-11e7-8e3d-666e31bf4397.png)
