### PR TITLE
Fix Triangulator for verts > 12

### DIFF
--- a/Nez.Portable/Utils/Triangulator.cs
+++ b/Nez.Portable/Utils/Triangulator.cs
@@ -113,7 +113,7 @@ namespace Nez
             if( _triNext.Length < count )
                 Array.Resize( ref _triNext, Math.Max( _triNext.Length * 2, count ) );
             if( _triPrev.Length < count )
-                Array.Resize( ref _triPrev, Math.Min( _triPrev.Length * 2, count ) );
+                Array.Resize( ref _triPrev, Math.Max( _triPrev.Length * 2, count ) );
 
             for( var i = 0; i < count; i++ )
 			{


### PR DESCRIPTION
Fixes an out of range crash when the number of verts is > than the default 12.
Example:
``` c#
verts = new Vector2[28];
var triangulator = new Triangulator();
triangulator.triangulate(verts, true); // crash here
```