### PR TITLE
Mesh.recalculateBounds() now causes the bounds to be recalculated.

### DIFF
--- a/Nez.Portable/ECS/Components/Renderables/Mesh.cs
+++ b/Nez.Portable/ECS/Components/Renderables/Mesh.cs
@@ -64,6 +64,7 @@ namespace Nez
 
 			_width = max.X - _topLeftVertPosition.X;
 			_height = max.Y - _topLeftVertPosition.Y;
+			_areBoundsDirty = true;
 
 			// handle UVs if need be
 			if( recalculateUVs )


### PR DESCRIPTION
When dynamically updating a mesh's verts, the bounds are not recalculated when calling recalculateBounds().  This fix sets them as dirty, so that the bounds will get recalculated lazily the next time they are accessed in the bounds prop.