### PR TITLE
Adding support for PrimitiveType.TriangleStrip in Mesh

### DIFF
--- a/Nez.Portable/ECS/Components/Renderables/Mesh.cs
+++ b/Nez.Portable/ECS/Components/Renderables/Mesh.cs
@@ -204,9 +204,9 @@ namespace Nez
 		/// </summary>
 		/// <param name="primitiveType">The ordering of the verticies.</param>
 		/// <returns>The mesh.</returns>
-		public Mesh setPrimitiveType(PrimitiveType primitiveType)
+		public Mesh setPrimitiveType( PrimitiveType primitiveType )
 		{
-			Assert.isTrue(primitiveType == PrimitiveType.TriangleList || primitiveType == PrimitiveType.TriangleStrip, "Only triangles are supported.");
+			Assert.isTrue( primitiveType == PrimitiveType.TriangleList || primitiveType == PrimitiveType.TriangleStrip, "Only triangles are supported." );
 			_primitiveType = primitiveType;
 			return this;
 		}
@@ -244,13 +244,13 @@ namespace Nez
 			_basicEffect.World = entity.transform.localToWorldTransform;
 			_basicEffect.CurrentTechnique.Passes[0].Apply();
 
-			if (_primitiveType == PrimitiveType.TriangleList)
+			if( _primitiveType == PrimitiveType.TriangleList )
 			{
-				Core.graphicsDevice.DrawUserIndexedPrimitives(_primitiveType, _verts, 0, _verts.Length, _triangles, 0, _primitiveCount);
+				Core.graphicsDevice.DrawUserIndexedPrimitives( _primitiveType, _verts, 0, _verts.Length, _triangles, 0, _primitiveCount );
 			}
-			else if (_primitiveType == PrimitiveType.TriangleStrip)
+			else if( _primitiveType == PrimitiveType.TriangleStrip )
 			{
-				Core.graphicsDevice.DrawUserPrimitives(_primitiveType, _verts, 0, _verts.Length - 2);
+				Core.graphicsDevice.DrawUserPrimitives( _primitiveType, _verts, 0, _verts.Length - 2 );
 			}
 		}
 

--- a/Nez.Portable/ECS/Components/Renderables/Mesh.cs
+++ b/Nez.Portable/ECS/Components/Renderables/Mesh.cs
@@ -41,6 +41,7 @@ namespace Nez
 		float _height;
 		int[] _triangles;
 		VertexPositionColorTexture[] _verts;
+		PrimitiveType _primitiveType = PrimitiveType.TriangleList;
 
 
 		#region configuration
@@ -197,6 +198,19 @@ namespace Nez
 			return this;
 		}
 
+		/// <summary>
+		/// Change the rendering primitive type.
+		/// If it is PrimitiveType.TriangleStrip then you don't need to setTriangles.
+		/// </summary>
+		/// <param name="primitiveType">The ordering of the verticies.</param>
+		/// <returns>The mesh.</returns>
+		public Mesh setPrimitiveType(PrimitiveType primitiveType)
+		{
+			Assert.isTrue(primitiveType == PrimitiveType.TriangleList || primitiveType == PrimitiveType.TriangleStrip, "Only triangles are supported.");
+			_primitiveType = primitiveType;
+			return this;
+		}
+
 		#endregion
 
 
@@ -230,7 +244,14 @@ namespace Nez
 			_basicEffect.World = entity.transform.localToWorldTransform;
 			_basicEffect.CurrentTechnique.Passes[0].Apply();
 
-			Core.graphicsDevice.DrawUserIndexedPrimitives( PrimitiveType.TriangleList, _verts, 0, _verts.Length, _triangles, 0, _primitiveCount );
+			if (_primitiveType == PrimitiveType.TriangleList)
+			{
+				Core.graphicsDevice.DrawUserIndexedPrimitives(_primitiveType, _verts, 0, _verts.Length, _triangles, 0, _primitiveCount);
+			}
+			else if (_primitiveType == PrimitiveType.TriangleStrip)
+			{
+				Core.graphicsDevice.DrawUserPrimitives(_primitiveType, _verts, 0, _verts.Length - 2);
+			}
 		}
 
 		#endregion


### PR DESCRIPTION
TriangleStrips are nicer than TriangleLists because the triangle indices don't need to be calculated.  Many modeling programs export data as strips.

The primitive count (number of tris) in a triangle strip is `_verts.Length - 2`. 
3 verts are 1 triangle (first triangle is vert 0, 1, 2)
4 verts are 2 triangles (the second triangle is vert 1, 2, and 3)

This PR keeps the current default functionality of Mesh to use TriangleLists, and adds a new function `Mesh.setPrimitiveType(PrimitiveType)`  If the primitive type is set to strips, then the cheaper DrawUserPrimitives call is made which sends less data to the GPU.