### PR TITLE
Screen added DisplayOrientation to support portrait on Mobile

### DIFF
--- a/Nez.Portable/Utils/Screen.cs
+++ b/Nez.Portable/Utils/Screen.cs
@@ -105,6 +105,13 @@ namespace Nez
 		}
 
 
+		public static DisplayOrientation supportedOrientations
+		{
+			get { return _graphicsManager.SupportedOrientations; }
+			set { _graphicsManager.SupportedOrientations = value; }
+		}
+
+
 		public static void applyChanges()
 		{
 			_graphicsManager.ApplyChanges();


### PR DESCRIPTION
This change is needed so that mobile can display in Portrait mode.
For example:
```c#
		public Game1()
		{
			Screen.supportedOrientations =
				DisplayOrientation.LandscapeLeft |
				DisplayOrientation.LandscapeRight |
				DisplayOrientation.Portrait |
				DisplayOrientation.PortraitDown;
		}
```