### PR TITLE
Added support for libgdx atlas animations

### DIFF
--- a/Nez.PipelineImporter/LibGdxAtlases/LibGdxAtlasWriter.cs
+++ b/Nez.PipelineImporter/LibGdxAtlases/LibGdxAtlasWriter.cs
@@ -32,7 +32,7 @@ namespace Nez.LibGdxAtlases
 				{
 					if( region.page == page.textureFile )
 					{
-						LibGdxAtlasProcessor.logger.LogMessage( "Writing region: {0}", region.name );
+						LibGdxAtlasProcessor.logger.LogMessage( "Writing region: {0} {1}", region.name, region.index == -1 ? string.Empty : $"(index {region.index})" );
 						writer.Write( region.name );
 						writer.Write( region.sourceRectangle.x );
 						writer.Write( region.sourceRectangle.y );
@@ -66,6 +66,8 @@ namespace Nez.LibGdxAtlases
 							writer.Write( region.pads[3] );
 							LibGdxAtlasProcessor.logger.LogMessage( "Writing pads for region: {0}", region.name );
 						}
+
+						writer.Write( region.index );
 					}
 				}
 			}

--- a/Nez.Portable/PipelineRuntime/LibGdxAtlases/LibGdxAtlas.cs
+++ b/Nez.Portable/PipelineRuntime/LibGdxAtlases/LibGdxAtlas.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using Nez.Sprites;
 using Nez.TextureAtlases;
 using Nez.Textures;
 
@@ -10,6 +11,7 @@ namespace Nez.LibGdxAtlases
 	public class LibGdxAtlas
 	{
 		public List<TextureAtlas> atlases = new List<TextureAtlas>();
+		public Dictionary<string, List<Subtexture>> animations = new Dictionary<string, List<Subtexture>>();
 
 
 		/// <summary>
@@ -52,6 +54,15 @@ namespace Nez.LibGdxAtlases
 		public Subtexture getSubtexture( string name )
 		{
 			return get( name );
+		}
+		/// <summary>
+		/// gets the sprite animation frames for a given name
+		/// </summary>
+		/// <param name="name">name of the anmation</param>
+		/// <returns></returns>
+		public List<Subtexture> getAnimation( string name )
+		{
+			return animations[name];
 		}
 	}
 }

--- a/Nez.Portable/PipelineRuntime/LibGdxAtlases/LibGdxAtlasReader.cs
+++ b/Nez.Portable/PipelineRuntime/LibGdxAtlases/LibGdxAtlasReader.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework.Content;
+﻿using System.Collections.Generic;
+using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using Nez.Pipeline.Content;
 using Microsoft.Xna.Framework;
@@ -46,6 +47,21 @@ namespace Nez.LibGdxAtlases
 						( (NinePatchSubtexture)subtextures[i] ).padRight = reader.ReadInt32();
 						( (NinePatchSubtexture)subtextures[i] ).padTop = reader.ReadInt32();
 						( (NinePatchSubtexture)subtextures[i] ).padBottom = reader.ReadInt32();
+					}
+
+					var index = reader.ReadInt32();
+
+					// animation
+					if ( index != -1 )
+					{
+						List<Subtexture> frames;
+						if ( !atlasContainer.animations.TryGetValue( name, out frames ) )
+						{
+							frames = new List<Subtexture>();
+							atlasContainer.animations[name] = frames;
+						}
+
+						frames.Insert( index, subtextures[i] );
 					}
 
 					regionNames[i] = name;


### PR DESCRIPTION
Support for animations in libGDX atlases, based on the index key which is -1 for standalone images and 0..n for animations. Due to the fact animations can be spread across pages using the sprite animations functionality from TextureAtlas was not possible.

**Note**: Breaks binary compatibility with existing content files due to writing region index to the file for each region.