### PR TITLE
added CameraStyle ctor parameter

### DIFF
--- a/Nez.Portable/ECS/Components/FollowCamera.cs
+++ b/Nez.Portable/ECS/Components/FollowCamera.cs
@@ -52,14 +52,15 @@ namespace Nez
 		RectangleF _worldSpaceDeadzone;
 
 		
-		public FollowCamera( Entity targetEntity, Camera camera )
+		public FollowCamera( Entity targetEntity, Camera camera, CameraStyle cameraStyle = CameraStyle.LockOn  )
 		{
 			_targetEntity = targetEntity;
+			_cameraStyle = cameraStyle;
 			this.camera = camera;
 		}
 
 
-		public FollowCamera( Entity targetEntity ) : this( targetEntity, null )
+		public FollowCamera( Entity targetEntity, CameraStyle cameraStyle = CameraStyle.LockOn ) : this( targetEntity, null, cameraStyle )
 		{}
 
 


### PR DESCRIPTION
I'm adding the ability to specify the FollowCamera's CameraStyle on instantiation because it's unclear how to set it otherwise. 

Calling 'follow' right away is awkward because you have to specify the camera as a ctor parameter, which you normally don't need to, and you need to specify the same entity that you just used to new up the FollowCamera, which seems unnecessary.

And I made LockOn the default because that's the value '_cameraStyle' is set to when 'follow' is called from 'onAddedToEntity', which is how it's usually set. This is a different default than used in 'follow', but I don't want to risk changing the camera behavior of anyone's game that isn't going through the extra work to set it explicitly.