### PR TITLE
Fixes the Pressed method for up and right on the left thumbstick

### DIFF
--- a/Nez.Portable/Input/GamePadData.cs
+++ b/Nez.Portable/Input/GamePadData.cs
@@ -198,7 +198,7 @@ namespace Nez
 		/// <param name="deadzone">Deadzone.</param>
 		public bool isLeftStickRightPressed( float deadzone = Input.DEFAULT_DEADZONE )
 		{
-			return _currentState.ThumbSticks.Left.X < deadzone && _previousState.ThumbSticks.Left.X > deadzone;
+			return _currentState.ThumbSticks.Left.X > deadzone && _previousState.ThumbSticks.Left.X < deadzone;
 		}
 
 
@@ -215,7 +215,7 @@ namespace Nez
 		/// <param name="deadzone">Deadzone.</param>
 		public bool isLeftStickUpPressed( float deadzone = Input.DEFAULT_DEADZONE )
 		{
-			return _currentState.ThumbSticks.Left.Y < deadzone && _previousState.ThumbSticks.Left.Y > deadzone;
+			return _currentState.ThumbSticks.Left.Y > deadzone && _previousState.ThumbSticks.Left.Y < deadzone;
 		}
 
 


### PR DESCRIPTION
There was a bug where the `...UpPressed()` and `...RightPressed()` methods for the left thumbstick of a gamepad had its checks against the deadzone backwards. This resulted in the method acting like a "released" check instead of a "pressed" check.

This fixes that issue by correctly checking against the deadzone.