### PR TITLE
Wrong value for checking if there is only one word

### DIFF
--- a/Nez.Portable/ECS/Components/Text/MarkupText.cs
+++ b/Nez.Portable/ECS/Components/Text/MarkupText.cs
@@ -314,7 +314,7 @@ namespace Nez
 						var currentWordFits = position.X + wordRunSize + wordSize.X <= _textWidth;
 
 						// if there is only one word and it doesnt fit we are gonna add it anyway else we will have nothing to show
-						if( wordRunSize == 0 && !currentWordFits )
+						if( words.Length == 0 && !currentWordFits )
 							currentWordFits = true;
 
 						if( currentWordFits )


### PR DESCRIPTION
if want to check if there is just one word, then need to check words.Length not wordRunSize