### PR TITLE
Use Stream.CopyTo in EffectResource.getFileResourceBytes

### DIFF
--- a/Nez.Portable/Graphics/Effects/EffectResource.cs
+++ b/Nez.Portable/Graphics/Effects/EffectResource.cs
@@ -102,8 +102,11 @@ namespace Nez
 			{
 				using( var stream = TitleContainer.OpenStream( path ) )
 				{
-					bytes = new byte[stream.Length];
-					stream.Read( bytes, 0, bytes.Length );
+					using ( var ms = new MemoryStream() )
+					{
+						stream.CopyTo( ms );
+						bytes = ms.ToArray();
+					}
 				}
 			}
 			catch( Exception e )


### PR DESCRIPTION
Stream.Length is not supported on all platforms.