### PR TITLE
Made internal SpriteAnimation properties public

### DIFF
--- a/Nez.Portable/ECS/Components/Renderables/Sprites/SpriteAnimation.cs
+++ b/Nez.Portable/ECS/Components/Renderables/Sprites/SpriteAnimation.cs
@@ -54,8 +54,8 @@ namespace Nez.Sprites
 		public List<Subtexture> frames = new List<Subtexture>();
 
 		// calculated values used by SpriteT
-		internal float secondsPerFrame;
-		internal float iterationDuration;
+		public float secondsPerFrame;
+		public float iterationDuration;
 
 		float _fps = 10;
 		bool _loop = true;


### PR DESCRIPTION
Wanted to make a modified Sprite\<TEnum\> but it depended on these internal properties, I figure they're worth exposing for general use.