### PR TITLE
Color markup

### DIFF
--- a/Nez.Portable/PipelineRuntime/BitmapFonts/BitmapFont.cs
+++ b/Nez.Portable/PipelineRuntime/BitmapFonts/BitmapFont.cs
@@ -96,7 +96,7 @@ namespace Nez.BitmapFonts
 		public string wrapText( string text, float maxLineWidth )
 		{
 			var ret = text;
-            var accw = 0f;
+			var accw = 0f;
             var charAdded = 0;
             for( var i = 0; i < text.Length; i++ )
             {

--- a/Nez.Portable/PipelineRuntime/BitmapFonts/BitmapFont.cs
+++ b/Nez.Portable/PipelineRuntime/BitmapFonts/BitmapFont.cs
@@ -224,6 +224,7 @@ namespace Nez.BitmapFonts
 			var offset = Vector2.Zero;
 			
 			var skip = -1;
+			
 			for( var i = 0; i < text.Length; i++ )
 			{
 				var c = text[i];

--- a/Nez.Portable/Utils/Fonts/FontCharacterSource.cs
+++ b/Nez.Portable/Utils/Fonts/FontCharacterSource.cs
@@ -13,6 +13,10 @@ namespace Nez
 		readonly StringBuilder _builder;
 		public readonly int Length;
 
+		public string value
+		{
+			get { return _string; }
+		}
 
 		public FontCharacterSource( string s )
 		{


### PR DESCRIPTION
```c#
            var test = new Label("" +
                                        "[#FF00FF]H[]" +
                                        "[#00FFFF]e[]" +
                                        "[#0000FF]l[]" +
                                        "[#FF0000]l[]" +
                                        "[#3300FF]o[] "
                                        +
                                        "[#FF0033]c[]" +
                                        "[#FF33FF]o[]" +
                                        "[#FF00FF]l[]" +
                                        "[#F408AF]o[]" +
                                        "[#44AAFF]r[]" +
                                        "[#220033]e[]" +
                                        "[#FAF02F]d[] "
                                        +
                                        "[#F4603F]w[]" +
                                        "[#FA801F]o[]" +
                                        "[#F1E08F]r[]" +
                                        "[#F0E0BF]l[]" +
                                        "[#FD05FF]d[]", skin);
```

Will produce:

![2017-09-12_22-46-40](https://user-images.githubusercontent.com/27389256/30347577-df1ce202-980c-11e7-9c51-90e7caa68d69.png)

No regex, no garbage, fast, easy to use :)