### PR TITLE
Fixed Tiled importing issue

### DIFF
--- a/Nez.PipelineImporter/Tiled/TiledMapWriter.cs
+++ b/Nez.PipelineImporter/Tiled/TiledMapWriter.cs
@@ -56,6 +56,8 @@ namespace Nez.TiledMaps
 				writer.Write( tileset.tileHeight );
 				writer.Write( tileset.spacing );
 				writer.Write( tileset.margin );
+				writer.Write( tileset.tileCount );
+				writer.Write( tileset.columns );
 				writeCustomProperties( writer, tileset.properties );
 
 				writer.Write( tileset.tiles.Count );

--- a/Nez.PipelineImporter/Tiled/TmxTileset.cs
+++ b/Nez.PipelineImporter/Tiled/TmxTileset.cs
@@ -35,6 +35,12 @@ namespace Nez.TiledMaps
 		[XmlAttribute( AttributeName = "margin" )]
 		public int margin;
 
+		[XmlAttribute( AttributeName = "tilecount" )]
+		public int tileCount;
+
+		[XmlAttribute( AttributeName = "columns" )]
+		public int columns;
+
 		[XmlElement( ElementName = "tileoffset" )]
 		public TmxTileOffset tileOffset;
 

--- a/Nez.Portable/PipelineRuntime/Tiled/TiledMap.cs
+++ b/Nez.Portable/PipelineRuntime/Tiled/TiledMap.cs
@@ -56,11 +56,11 @@ namespace Nez.Tiled
 
 		#region Tileset and Layer creation
 
-		public TiledTileset createTileset( Texture2D texture, int firstId, int tileWidth, int tileHeight, bool isStandardTileset, int spacing = 2, int margin = 2 )
+		public TiledTileset createTileset( Texture2D texture, int firstId, int tileWidth, int tileHeight, bool isStandardTileset, int spacing = 2, int margin = 2, int tileCount = 1, int columns = 1 )
 		{
 			TiledTileset tileset;
 			if( isStandardTileset )
-				tileset = new TiledTileset( texture, firstId, tileWidth, tileHeight, spacing, margin );
+				tileset = new TiledTileset( texture, firstId, tileWidth, tileHeight, spacing, margin, tileCount, columns );
 			else
 				tileset = new TiledImageCollectionTileset( texture, firstId );
 

--- a/Nez.Portable/PipelineRuntime/Tiled/TiledMapReader.cs
+++ b/Nez.Portable/PipelineRuntime/Tiled/TiledMapReader.cs
@@ -54,7 +54,9 @@ namespace Nez.Tiled
 										tileHeight: reader.ReadInt32(),
 										isStandardTileset: isStandardTileset,
 										spacing: reader.ReadInt32(),
-										margin: reader.ReadInt32() );
+										margin: reader.ReadInt32(),
+										tileCount: reader.ReadInt32(),
+										columns: reader.ReadInt32() );
 				readCustomProperties( reader, tileset.properties );
 
 				// tiledset tile array

--- a/Nez.Portable/PipelineRuntime/Tiled/TiledTileSet.cs
+++ b/Nez.Portable/PipelineRuntime/Tiled/TiledTileSet.cs
@@ -27,7 +27,7 @@ namespace Nez.Tiled
 		}
 
 
-		public TiledTileset( Texture2D texture, int firstId, int tileWidth, int tileHeight, int spacing = 2, int margin = 2 )
+		public TiledTileset( Texture2D texture, int firstId, int tileWidth, int tileHeight, int spacing = 2, int margin = 2, int tileCount = 2, int columns = 2 )
 		{
 			this.texture = texture;
 			this.firstId = firstId;
@@ -40,10 +40,15 @@ namespace Nez.Tiled
 			_regions = new Dictionary<int,Subtexture>();
 			for( var y = margin; y < texture.Height - margin; y += tileHeight + spacing )
 			{
+				var column = 0;
+
 				for( var x = margin; x < texture.Width - margin; x += tileWidth + spacing )
 				{
 					_regions.Add( id, new Subtexture( texture, x, y, tileWidth, tileHeight ) );
 					id++;
+
+					if( ++column >= columns ) 
+						break;
 				}
 			}
 		}


### PR DESCRIPTION
So there's an issue with the way the PipelineImporter is currently reading Tiled maps.

What happens is, Tiled disregards part of the tileset image that does not consist of evenly-sized tiles. For all intents and purposes let's assume that we have a tileset with 30px of tile height and width. If the tileset image is 160px wide this only leaves room for 5 tile columns (5 x 30 = 150) and the remaining 10px are actually ignored by Tiled.

Now all this is probably intended, but what happened to me when trying to import such a map is that the reader actually mistook that extra space off the edge as a tile since it had not yet reached its `x < texture.Width - margin` clause. But since we just assigned an id to the non-existing tile, we are now one id behind Tiled's id accounting, per row. So every tile after the first row had the wrong id and the tilemap was unrecognizable.

So I put together a quick fix for my own project that takes the `columns` attribute into account to correct this issue. It's not much but I hope I can contribute more in the future :)