### PR TITLE
Fix for #309 - Sprite<T> animation complete behavior

### DIFF
--- a/Nez.Portable/ECS/Components/Renderables/Sprites/SpriteT.cs
+++ b/Nez.Portable/ECS/Components/Renderables/Sprites/SpriteT.cs
@@ -77,6 +77,20 @@ namespace Nez.Sprites
 
 		#region Component overrides
 
+		public override RectangleF bounds
+		{
+			get
+			{
+				if( _areBoundsDirty && subtexture != null )
+				{
+					_bounds.calculateBounds( entity.transform.position, _localOffset, _origin, entity.transform.scale, entity.transform.rotation, subtexture.sourceRect.Width, subtexture.sourceRect.Height );
+					_areBoundsDirty = false;
+				}
+
+				return _bounds;
+			}
+		}
+
 		void IUpdatable.update()
 		{
 			if( _currentAnimation == null || !isPlaying )

--- a/Nez.Portable/Graphics/Batcher/Batcher.cs
+++ b/Nez.Portable/Graphics/Batcher/Batcher.cs
@@ -809,6 +809,11 @@ namespace Nez
 		void pushSprite( Subtexture subtexture, float destinationX, float destinationY, float destinationW, float destinationH, Color color, Vector2 origin,
 				float rotation, float depth, byte effects, float skewTopX, float skewBottomX, float skewLeftY, float skewRightY )
 		{
+			if( subtexture == null )
+			{
+				return;
+			}
+
 			// out of space, flush
 			if( _numSprites >= MAX_SPRITES )
 				flushBatch();


### PR DESCRIPTION
My fix for #309
* Overrode the way the bounds are calculated for sprite<T> becuase it is possible for the subtexture to become null
* Added a null check for subtexture  to the batcher push sprite method because subtexture can become null

Felt like null checking was a cleaner fix but could instead add the disable/enable if the maintainers feel otherwise.