### PR TITLE
Fix infinite loop in linecast

### DIFF
--- a/Nez.Portable/Physics/SpatialHash.cs
+++ b/Nez.Portable/Physics/SpatialHash.cs
@@ -277,8 +277,8 @@ namespace Nez.Spatial
 			// TODO: check gridBounds to ensure the ray starts/ends in the grid. watch out for end cells since they report out of bounds due to int comparison
 
 			// what voxel are we on
-			var intX = Mathf.fastFloorToInt( start.X );
-			var intY = Mathf.fastFloorToInt( start.Y );
+			var intX = Mathf.floorToInt( start.X );
+			var intY = Mathf.floorToInt( start.Y );
 
 			// which way we go
 			var stepX = Math.Sign( ray.direction.X );


### PR DESCRIPTION
Use consistent floor method in linecasting to avoid an edge case where the start and end are in the same voxel but are floor()'ed to different integers, causing an infinite loop.