### PR TITLE
Handle vertical lines in ShapeCollision.lineToPoly.

### DIFF
--- a/Nez.Portable/Physics/Shapes/ShapeCollisions/ShapeCollisionsLine.cs
+++ b/Nez.Portable/Physics/Shapes/ShapeCollisions/ShapeCollisionsLine.cs
@@ -25,7 +25,7 @@ namespace Nez.PhysicsShapes
 					// TODO: is this the correct and most efficient way to get the fraction?
 					// check x fraction first. if it is NaN use y instead
 					var distanceFraction = ( intersection.X - start.X ) / ( end.X - start.X );
-					if( float.IsNaN( distanceFraction ) )
+					if( float.IsNaN( distanceFraction ) || float.IsInfinity( distanceFraction ) )
 						distanceFraction = ( intersection.Y - start.Y ) / ( end.Y - start.Y );
 
 					if( distanceFraction < fraction )


### PR DESCRIPTION
For line segments that are vertical, the first calculation results in a
division by 0, which is Infinity. The resulting RaycastHit is never set
up properly.