### PR TITLE
Make collider transforms dirty on enable in case parent has moved.

### DIFF
--- a/Nez.Portable/ECS/Components/Physics/Colliders/Collider.cs
+++ b/Nez.Portable/ECS/Components/Physics/Colliders/Collider.cs
@@ -214,6 +214,7 @@ namespace Nez
 		public override void onEnabled()
 		{
 			registerColliderWithPhysicsSystem();
+			_isPositionDirty = _isRotationDirty = true;
 		}
 
 


### PR DESCRIPTION
Addresses the issue in #324