### PR TITLE
Fix for Button firing multiple times per click at a high framerate.

### DIFF
--- a/Nez.Portable/UI/Widgets/Button.cs
+++ b/Nez.Portable/UI/Widgets/Button.cs
@@ -137,6 +137,7 @@ namespace Nez.UI
 
 		void IInputListener.onMouseUp( Vector2 mousePos )
 		{
+			if (!_mouseDown) return; //onMouseUp has already been fired once.
 			_mouseDown = false;
 
 			setChecked( !_isChecked, true );


### PR DESCRIPTION
UI.Button's implementation of `IInputListener.onMouseUp` will fire multiple times for each button click because the inputFocusListeners keep accumulating while the mouse is pressed. When the mouse is released onMouseUp gets called for every one of these listeners.

Adding a check to see if the mouse is down before firing the OnClicked event or toggling the button prevents them from being fired multiple times.

Could even add an OnHeld event with little effort if that was desired functionality, but I think a single click was the intended function for OnClicked.