### PR TITLE
Switched entity dictionary to use FastList for for faster sorting.

### DIFF
--- a/Nez.Portable/ECS/InternalUtils/EntityList.cs
+++ b/Nez.Portable/ECS/InternalUtils/EntityList.cs
@@ -130,7 +130,7 @@ namespace Nez
 		}
 
 
-		List<Entity> getTagList( int tag )
+		FastList<Entity> getTagList( int tag )
 		{
 			FastList<Entity> list = null;
 			if( !_entityDict.TryGetValue( tag, out list ) )
@@ -139,16 +139,16 @@ namespace Nez
 				_entityDict[tag] = list;
 			}
 
-			return _entityDict[tag].toList();
+			return _entityDict[tag];
 		}
 
 
 		internal void addToTagList( Entity entity )
 		{
 			var list = getTagList( entity.tag );
-			Assert.isFalse( list.Contains( entity ), "Entity tag list already contains this entity: {0}", entity );
+			Assert.isFalse( list.contains( entity ), "Entity tag list already contains this entity: {0}", entity );
 
-			list.Add( entity );
+			list.add( entity );
 			_unsortedTags.Add( entity.tag );
 		}
 
@@ -277,7 +277,11 @@ namespace Nez
 			var list = getTagList( tag );
 
 			var returnList = ListPool<Entity>.obtain();
-			returnList.AddRange( list );
+			returnList.Capacity = _entities.length;
+			for( var i = 0; i < list.length; i++ )
+			{
+				returnList.Add( _entities.buffer[i] );
+			}
 
 			return returnList;
 		}

--- a/Nez.Portable/ECS/InternalUtils/EntityList.cs
+++ b/Nez.Portable/ECS/InternalUtils/EntityList.cs
@@ -139,7 +139,7 @@ namespace Nez
 				_entityDict[tag] = list;
 			}
 
-			return new List<Entity>( _entityDict[tag].buffer );
+			return _entityDict[tag].toList();
 		}
 
 

--- a/Nez.Portable/ECS/InternalUtils/EntityList.cs
+++ b/Nez.Portable/ECS/InternalUtils/EntityList.cs
@@ -30,7 +30,7 @@ namespace Nez
 		/// <summary>
 		/// tracks entities by tag for easy retrieval
 		/// </summary>
-		Dictionary<int,List<Entity>> _entityDict = new Dictionary<int, List<Entity>>();
+		Dictionary<int, FastList<Entity>> _entityDict = new Dictionary<int, FastList<Entity>>();
 		List<int> _unsortedTags = new List<int>();
 
 		// used in updateLists to double buffer so that the original lists can be modified elsewhere
@@ -99,7 +99,7 @@ namespace Nez
 		/// </summary>
 		public void removeAllEntities()
 		{
-			// clear lists we dont need anymore
+			// clear lists we don't need anymore
 			_unsortedTags.Clear();
 			_entitiesToAdd.Clear();
 			_isEntityListUnsorted = false;
@@ -132,14 +132,14 @@ namespace Nez
 
 		List<Entity> getTagList( int tag )
 		{
-			List<Entity> list = null;
+			FastList<Entity> list = null;
 			if( !_entityDict.TryGetValue( tag, out list ) )
 			{
-				list = new List<Entity>();
+				list = new FastList<Entity>();
 				_entityDict[tag] = list;
 			}
 
-			return _entityDict[tag];
+			return new List<Entity>( _entityDict[tag].buffer );
 		}
 
 
@@ -155,7 +155,7 @@ namespace Nez
 
 		internal void removeFromTagList( Entity entity )
 		{
-			_entityDict[entity.tag].Remove( entity );
+			_entityDict[entity.tag].remove( entity );
 		}
 
 
@@ -234,7 +234,7 @@ namespace Nez
 				for( int i = 0, count = _unsortedTags.Count; i < count; i++ )
 				{
 					var tag = _unsortedTags[i];
-					_entityDict[tag].Sort();
+					_entityDict[tag].sort();
 				}
 				_unsortedTags.Clear();
 			}

--- a/Nez.Portable/Utils/Collections/FastList.cs
+++ b/Nez.Portable/Utils/Collections/FastList.cs
@@ -182,19 +182,6 @@ namespace Nez
 			Array.Sort( buffer, 0, length, comparer );
 		}
 
-		/// <summary>
-		/// returns a list of items in the buffer up to length
-		/// </summary>
-		public List<T> toList()
-		{
-			var list = new List<T>( length );
-			for( var i = 0; i < length; ++i )
-			{
-				list.Add( buffer[i] );
-			}
-			return list;
-		}
-
 	}
 }
 

--- a/Nez.Portable/Utils/Collections/FastList.cs
+++ b/Nez.Portable/Utils/Collections/FastList.cs
@@ -182,6 +182,19 @@ namespace Nez
 			Array.Sort( buffer, 0, length, comparer );
 		}
 
+		/// <summary>
+		/// returns a list of items in the buffer up to length
+		/// </summary>
+		public List<T> toList()
+		{
+			var list = new List<T>( length );
+			for( var i = 0; i < length; ++i )
+			{
+				list.Add( buffer[i] );
+			}
+			return list;
+		}
+
 	}
 }
 


### PR DESCRIPTION
I noticed that list sorting was one of a couple causes of slowdowns within my game. There are two places that the entities within this class are sorted, one uses FastList<T> and the other uses List<T>. It was the second one that was causing the slowdown. So I switched the entity tag dictionary to also use FastList<T>, which made my test case go from ~6.5 seconds to a little over 4.