### PR TITLE
FollowCamera doesn't use zoomed camera bounds

### DIFF
--- a/Nez.Portable/ECS/Components/FollowCamera.cs
+++ b/Nez.Portable/ECS/Components/FollowCamera.cs
@@ -85,7 +85,7 @@ namespace Nez
 		void IUpdatable.update()
 		{
 			// translate the deadzone to be in world space
-			var halfScreen = entity.scene.sceneRenderTargetSize.ToVector2() * 0.5f;
+			var halfScreen = camera.bounds.size * 0.5f;
 			_worldSpaceDeadzone.x = camera.position.X - halfScreen.X + deadzone.x + focusOffset.X;
 			_worldSpaceDeadzone.y = camera.position.Y - halfScreen.Y + deadzone.y + focusOffset.Y;
 			_worldSpaceDeadzone.width = deadzone.width;


### PR DESCRIPTION
I hope this is the right way to fix this issue, but it seems that the FollowCamera deadzone isn't referencing the zoomed camera bounds, which breaks it when the zoom level is different from the render target.

Resolves #294.