### PR TITLE
Fixed incorrect window title click check

### DIFF
--- a/Nez.Portable/UI/Widgets/Window.cs
+++ b/Nez.Portable/UI/Widgets/Window.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.Xna.Framework;
 using Nez.BitmapFonts;
 
@@ -264,22 +264,17 @@ namespace Nez.UI
 
 		public override Element hit( Vector2 point )
 		{
-			// TODO: is this correct? should we be transforming the point here?
-			if( !hasParent() )
-				point = stageToLocalCoordinates( point );
-
 			var hit = base.hit( point );
 			if( hit == null || hit == this )
 				return hit;
 
-			var height = getHeight();
-			if( y <= height && y >= height - getPadTop() && x >= 0 && x <= getWidth() )
+			if( point.Y >= 0 && point.Y <= getPadTop() && point.X >= 0 && point.X <= width )
 			{
 				// Hit the title bar, don't use the hit child if it is in the Window's table.
 				Element current = hit;
 				while( current.getParent() != this )
 					current = current.getParent();
-				
+
 				if( getCell( current ) != null )
 					return this;
 			}


### PR DESCRIPTION
Code that was supposed to check if the window title had been clicked (to ignore hits on elements under it) was totally whacky and was instead causing hits to be ignored when the window's x position was less than its width.

Resolves #284.