### PR TITLE
Fixed getFileResourceBytes NotSupportedException exception

### DIFF
--- a/Nez.Portable/Graphics/Effects/EffectResource.cs
+++ b/Nez.Portable/Graphics/Effects/EffectResource.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using Microsoft.Xna.Framework;
 
@@ -102,8 +102,19 @@ namespace Nez
 			{
 				using( var stream = TitleContainer.OpenStream( path ) )
 				{
-					bytes = new byte[stream.Length];
-					stream.Read( bytes, 0, bytes.Length );
+					if( stream.CanSeek )
+					{
+						bytes = new byte[stream.Length];
+						stream.Read( bytes, 0, bytes.Length );
+					}
+					else
+					{
+						using( var ms = new MemoryStream() )
+						{
+							stream.CopyTo( ms );
+							bytes = ms.ToArray();
+						}
+					}
 				}
 			}
 			catch( Exception e )


### PR DESCRIPTION
Resolves #292 and builds on @nhorne's PR (#270). Missing piece was to use [Stream.CanSeek](https://msdn.microsoft.com/en-us/library/system.io.stream.canseek.aspx) to determine if the workaround is necessary.