### PR TITLE
Fixed setting an entity's tag after adding it to a scene

### DIFF
--- a/Nez.Portable/ECS/InternalUtils/EntityList.cs
+++ b/Nez.Portable/ECS/InternalUtils/EntityList.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 namespace Nez
@@ -146,16 +146,21 @@ namespace Nez
 		internal void addToTagList( Entity entity )
 		{
 			var list = getTagList( entity.tag );
-			Assert.isFalse( list.contains( entity ), "Entity tag list already contains this entity: {0}", entity );
-
-			list.add( entity );
-			_unsortedTags.Add( entity.tag );
+			if( !list.contains( entity ) )
+			{
+				list.add( entity );
+				_unsortedTags.Add( entity.tag );
+			}
 		}
 
 
 		internal void removeFromTagList( Entity entity )
 		{
-			_entityDict[entity.tag].remove( entity );
+			FastList<Entity> list = null;
+			if( _entityDict.TryGetValue( entity.tag, out list ) )
+			{
+				list.remove( entity );
+			}
 		}
 
 


### PR DESCRIPTION
Resolves #347.

Test case:
~~~
public class GameScene: Scene
{
    public override void initialize()
    {
        var test = createEntity( "test" );
        test.tag = 1;
    }
}
~~~

Found 2 separate bugs that were preventing this from working.

The immediate bug was Entity::setTag() would call EntityList::removeFromTagList(), when the tag didn't exist yet, throwing a no key found exception.

After fixing that I also found that EntityList::addToTagList() would get called twice (once in setTag, and a second time in EntityList::updateLists() when processing a new entity. The double checking appears correct as it does cover off the 2 use cases (changing a tag before/after adding an entity), but it just happens to overlap if the entity is yet to be processed. Simple resolution was to remove the assert and have it silently have no effect when called multiple times.