### PR TITLE
Changes to ProgressBar.

### DIFF
--- a/Nez.Portable/UI/Widgets/ProgressBar.cs
+++ b/Nez.Portable/UI/Widgets/ProgressBar.cs
@@ -157,6 +157,18 @@ namespace Nez.UI
         }
 
 
+        /// <summary>
+        /// Sets stepSize to a value that will evenly divide this progress bar into specified amount of steps.
+        /// </summary>
+        /// <param name="totalSteps">Total amount of steps.</param>
+        public ProgressBar setTotalSteps( int totalSteps )
+        {
+            Assert.isTrue(totalSteps != 0, "totalSteps cannot be equal to 0");
+            _stepSize = Math.Abs((min - max) / totalSteps);
+            return this;
+        }
+
+
 		protected virtual IDrawable getKnobDrawable()
 		{
 			return ( disabled && style.disabledKnob != null ) ? style.disabledKnob : style.knob;

--- a/Nez.Portable/UI/Widgets/ProgressBar.cs
+++ b/Nez.Portable/UI/Widgets/ProgressBar.cs
@@ -6,8 +6,10 @@ using Microsoft.Xna.Framework.Input;
 namespace Nez.UI
 {
 	public class ProgressBar : Element
-	{
-		public event Action<float> onChanged;
+    {
+        #region properties and fields
+        
+        public event Action<float> onChanged;
 
 		public bool disabled;
 
@@ -31,30 +33,41 @@ namespace Nez.UI
 				else
 					return Math.Max( style.knob == null ? 0 : style.knob.minHeight, style.background != null ? style.background.minHeight : 0 );
 			}
-		}
+        }
 
-		public float[] snapValues;
+        public float min { get; protected set; }
+        public float max { get; protected set; }
+        public float stepSize { get; protected set; }
+
+        public float value
+        {
+            get { return _value; }
+            set { setValue(value); }
+        }
+
+        public float[] snapValues;
 		public float snapThreshold;
 		public bool shiftIgnoresSnap;
 
 		protected float _value;
-		protected float _min, _max, _stepSize;
 		protected bool _vertical;
 		protected float position;
 		ProgressBarStyle style;
 
+        #endregion
 
-		public ProgressBar( float min, float max, float stepSize, bool vertical, ProgressBarStyle style )
+
+        public ProgressBar( float min, float max, float stepSize, bool vertical, ProgressBarStyle style )
 		{
 			Assert.isTrue( min < max, "min must be less than max" );
 			Assert.isTrue( stepSize > 0, "stepSize must be greater than 0" );
 
 			setStyle( style );
-			_min = min;
-			_max = max;
-			_stepSize = stepSize;
+			this.min = min;
+			this.max = max;
+			this.stepSize = stepSize;
 			_vertical = vertical;
-			_value = _min;
+            _value = this.min;
 
 			setSize( preferredWidth, preferredHeight );
 		}
@@ -92,12 +105,12 @@ namespace Nez.UI
 		{
 			if( !shiftIgnoresSnap || !InputUtils.isShiftDown() )
 			{
-				value = Mathf.clamp( Mathf.round( value / _stepSize ) * _stepSize, _min, _max );
+				value = Mathf.clamp( Mathf.round( value / stepSize ) * stepSize, min, max );
 				value = snap( value );
 			}
 			else
 			{
-				value = Mathf.clamp( value, _min, _max );
+				value = Mathf.clamp( value, min, max );
 			}
 
 			if( value == _value )
@@ -115,9 +128,20 @@ namespace Nez.UI
 
 		public ProgressBar setStepSize( float stepSize )
 		{
-			_stepSize = stepSize;
+			this.stepSize = stepSize;
 			return this;
 		}
+
+
+        public ProgressBar setMinMax( float min, float max )
+        {
+            Assert.isTrue(min < max, "min must be less than max");
+            this.min = min;
+            this.max = max;
+            _value = Mathf.clamp(_value, this.min, this.max);
+
+            return this;
+        }
 
 
 		protected virtual IDrawable getKnobDrawable()
@@ -155,7 +179,7 @@ namespace Nez.UI
 				}
 
 				float knobHeightHalf = 0;
-				if( _min != _max )
+				if( min != max )
 				{
 					if( knob == null )
 					{
@@ -204,7 +228,7 @@ namespace Nez.UI
 				}
 
 				float knobWidthHalf = 0;
-				if( _min != _max )
+				if( min != max )
 				{
 					if( knob == null )
 					{
@@ -244,7 +268,7 @@ namespace Nez.UI
 
 		public float getVisualPercent()
 		{
-			return ( _value - _min ) / ( _max - _min );
+			return ( _value - min ) / ( max - min );
 		}
 
 

--- a/Nez.Portable/UI/Widgets/ProgressBar.cs
+++ b/Nez.Portable/UI/Widgets/ProgressBar.cs
@@ -110,7 +110,14 @@ namespace Nez.UI
 			}
 			else
             {
-                value = Mathf.clamp(Mathf.round(value / stepSize) * stepSize, min, max);
+                // if value is lower/higher than min/max then we're not rounding to avoid situation where we can't achieve those values
+                if (value >= max)
+                    value = max;
+                else if (value <= min)
+                    value = min;
+                else
+                    value = Mathf.clamp(Mathf.round(value / stepSize) * stepSize, min, max);
+
                 value = snap(value);
             }
 

--- a/Nez.Portable/UI/Widgets/ProgressBar.cs
+++ b/Nez.Portable/UI/Widgets/ProgressBar.cs
@@ -41,7 +41,7 @@ namespace Nez.UI
         public float stepSize
         {
             get { return _stepSize; }
-            set { setStepSize(_value); }
+            set { setStepSize(value); }
         }
 
         public float value

--- a/Nez.Portable/UI/Widgets/ProgressBar.cs
+++ b/Nez.Portable/UI/Widgets/ProgressBar.cs
@@ -97,21 +97,22 @@ namespace Nez.UI
 		}
 
 
-		/// <summary>
-		/// Sets the progress bar position, rounded to the nearest step size and clamped to the minimum and maximum values.
-		/// </summary>
-		/// <param name="value">Value.</param>
-		public ProgressBar setValue( float value )
+        /// <summary>
+        /// Sets the progress bar position, rounded to the nearest step size and clamped to the minimum and maximum values.
+        /// </summary>
+        /// <param name="value">Value.</param>
+        /// <param name="ignoreSnap">If set to <c>true</c> we ignore value snapping.</param>
+        public ProgressBar setValue( float value, bool ignoreSnap = false )
 		{
-			if( !shiftIgnoresSnap || !InputUtils.isShiftDown() )
-			{
-				value = Mathf.clamp( Mathf.round( value / stepSize ) * stepSize, min, max );
-				value = snap( value );
+			if( ( shiftIgnoresSnap && InputUtils.isShiftDown() ) || ignoreSnap )
+            {
+                value = Mathf.clamp(value, min, max);
 			}
 			else
-			{
-				value = Mathf.clamp( value, min, max );
-			}
+            {
+                value = Mathf.clamp(Mathf.round(value / stepSize) * stepSize, min, max);
+                value = snap(value);
+            }
 
 			if( value == _value )
 				return this;

--- a/Nez.Portable/UI/Widgets/ProgressBar.cs
+++ b/Nez.Portable/UI/Widgets/ProgressBar.cs
@@ -37,7 +37,12 @@ namespace Nez.UI
 
         public float min { get; protected set; }
         public float max { get; protected set; }
-        public float stepSize { get; protected set; }
+
+        public float stepSize
+        {
+            get { return _stepSize; }
+            set { setStepSize(_value); }
+        }
 
         public float value
         {
@@ -49,7 +54,7 @@ namespace Nez.UI
 		public float snapThreshold;
 		public bool shiftIgnoresSnap;
 
-		protected float _value;
+		protected float _stepSize, _value;
 		protected bool _vertical;
 		protected float position;
 		ProgressBarStyle style;
@@ -136,7 +141,7 @@ namespace Nez.UI
 
 		public ProgressBar setStepSize( float stepSize )
 		{
-			this.stepSize = stepSize;
+			_stepSize = stepSize;
 			return this;
 		}
 

--- a/Nez.Portable/UI/Widgets/Slider.cs
+++ b/Nez.Portable/UI/Widgets/Slider.cs
@@ -148,9 +148,9 @@ namespace Nez.UI
 		protected virtual void onUnhandledDirectionPressed( Direction direction )
 		{
 			if( direction == Direction.Up || direction == Direction.Right )
-				setValue( _value + _stepSize );
+				setValue( _value + stepSize );
 			else
-				setValue( _value - _stepSize );
+				setValue( _value - stepSize );
 		}
 
 
@@ -231,7 +231,7 @@ namespace Nez.UI
 				var height = this.height - style.background.topHeight - style.background.bottomHeight;
 				var knobHeight = knob == null ? 0 : knob.minHeight;
 				position = mousePos.Y - style.background.bottomHeight - knobHeight * 0.5f;
-				value = _min + ( _max - _min ) * ( position / ( height - knobHeight ) );
+				value = min + ( max - min ) * ( position / ( height - knobHeight ) );
 				position = Math.Max( 0, position );
 				position = Math.Min( height - knobHeight, position );
 			}
@@ -240,7 +240,7 @@ namespace Nez.UI
 				var width = this.width - style.background.leftWidth - style.background.rightWidth;
 				var knobWidth = knob == null ? 0 : knob.minWidth;
 				position = mousePos.X - style.background.leftWidth - knobWidth * 0.5f;
-				value = _min + ( _max - _min ) * ( position / ( width - knobWidth ) );
+				value = min + ( max - min ) * ( position / ( width - knobWidth ) );
 				position = Math.Max( 0, position );
 				position = Math.Min( width - knobWidth, position );
 			}


### PR DESCRIPTION
Changes with my reasoning behind them:

- Changed _min and _max into automatic properties (public getter, protected setter), added public properties for stepSize and value, added setMinMax() method --- I needed to both check and change those values in my project, and I believe having setter for min/max is better than creating new Slider each time I need to change min/max.
- Added parameter (bool, false by default) for setValue() that when true is going to ignore snapping values --- there was no reason to set value to anything (within min/max range) by manually calling setValue(), because snapping could only be avoided when holding shift.
- Reversed condition inside setValue() --- I believe that it's easier to understand, especially with another bool in there.
- When not snapping we first check if our value is lower/higher than min/max and set it to that value, and snap otherwise --- this prevents situation when we couldn't achieve min/max value with some values of stepSize (example below).
- Added setTotalSteps() method with int parameter. It's going to set stepSize to a value that will evenly divide this ProgressBar into specified amount of steps --- after using it often in my personal project I realized that having this method might be useful for others (it feels more convenient to have this method built in).


Example. Before change mentioned in 4th point:
`firstSlider = new Slider(0, 1, 0.51f, vertical, sliderStyle);`
`secondSlider = new Slider(0, 1, 0.99f, vertical, sliderStyle);`
The first slider can reach the max value after rounding easily.
The second slider either cannot reach it or you need to move your mouse far away from it, and even then it's inconsistent because onMouseExit() is going to be called.