### PR TITLE
Made FloatInspector and Vector2Inspector use CultureInfo.InvariantCulture for float .ToString() and .TryParse() method calls.

### DIFF
--- a/Nez.Portable/Debug/Inspector/Inspectors/FloatInspector.cs
+++ b/Nez.Portable/Debug/Inspector/Inspectors/FloatInspector.cs
@@ -1,4 +1,5 @@
 ﻿using Nez.UI;
+using System.Globalization;
 
 
 #if DEBUG
@@ -24,12 +25,12 @@ namespace Nez
 		void setupTextField( Table table, Skin skin, float leftCellWidth )
 		{
 			var label = createNameLabel( table, skin, leftCellWidth );
-			_textField = new TextField( getValue<float>().ToString(), skin );
+			_textField = new TextField( getValue<float>().ToString( CultureInfo.InvariantCulture ), skin );
 			_textField.setTextFieldFilter( new FloatFilter() );
 			_textField.onTextChanged += ( field, str ) =>
 			{
 				float newValue;
-				if( float.TryParse( str, out newValue ) )
+				if( float.TryParse( str, NumberStyles.Float, CultureInfo.InvariantCulture, out newValue ) )
 					setValue( newValue );
 			};
 
@@ -57,7 +58,7 @@ namespace Nez
 		public override void update()
 		{
 			if( _textField != null )
-				_textField.setText( getValue<float>().ToString() );
+				_textField.setText( getValue<float>().ToString( CultureInfo.InvariantCulture ));
 			if( _slider != null )
 				_slider.setValue( getValue<float>() );
 		}

--- a/Nez.Portable/Debug/Inspector/Inspectors/Vector2Inspector.cs
+++ b/Nez.Portable/Debug/Inspector/Inspectors/Vector2Inspector.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Nez.UI;
+using System.Globalization;
 
 
 #if DEBUG
@@ -16,12 +17,12 @@ namespace Nez
 			var label = createNameLabel( table, skin, leftCellWidth );
 
 			var labelX = new Label( "x", skin );
-			_textFieldX = new TextField( value.X.ToString(), skin );
+			_textFieldX = new TextField( value.X.ToString( CultureInfo.InvariantCulture ), skin );
 			_textFieldX.setTextFieldFilter( new FloatFilter() ).setPreferredWidth( 50 );
 			_textFieldX.onTextChanged += ( field, str ) =>
 			{
 				float newX;
-				if( float.TryParse( str, out newX ) )
+				if( float.TryParse( str, NumberStyles.Float, CultureInfo.InvariantCulture, out newX ) )
 				{
 					var newValue = getValue<Vector2>();
 					newValue.X = newX;
@@ -30,12 +31,12 @@ namespace Nez
 			};
 
 			var labelY = new Label( "y", skin );
-			_textFieldY = new TextField( value.Y.ToString(), skin );
+			_textFieldY = new TextField( value.Y.ToString( CultureInfo.InvariantCulture ), skin );
 			_textFieldY.setTextFieldFilter( new FloatFilter() ).setPreferredWidth( 50 );
 			_textFieldY.onTextChanged += ( field, str ) =>
 			{
 				float newY;
-				if( float.TryParse( str, out newY ) )
+				if( float.TryParse( str, NumberStyles.Float, CultureInfo.InvariantCulture, out newY ) )
 				{
 					var newValue = getValue<Vector2>();
 					newValue.Y = newY;
@@ -57,8 +58,8 @@ namespace Nez
 		public override void update()
 		{
 			var value = getValue<Vector2>();
-			_textFieldX.setText( value.X.ToString() );
-			_textFieldY.setText( value.Y.ToString() );
+			_textFieldX.setText( value.X.ToString( CultureInfo.InvariantCulture ) );
+			_textFieldY.setText( value.Y.ToString( CultureInfo.InvariantCulture ) );
 		}
 
 	}


### PR DESCRIPTION
This change was made to make those inspectors useable when used on a system with comma as default decimal separator.