### PR TITLE
Crossplatform clipboard implementation

### DIFF
--- a/Nez.Portable/Input/Clipboard.cs
+++ b/Nez.Portable/Input/Clipboard.cs
@@ -9,7 +9,12 @@ namespace Nez
 	public class Clipboard : IClipboard
 	{
 		static IClipboard _instance;
-		string _text;
+		
+		//The Monogame.Framework.dll.config maps SDL2.dll to platform specific libraries
+		[DllImport("SDL2.dll")]
+		private static extern int SDL_SetClipboardText(string text);
+		[DllImport("SDL2.dll")]
+		private static extern string SDL_GetClipboardText();
 
 
 		public static string getContents()
@@ -33,13 +38,13 @@ namespace Nez
 
 		string IClipboard.getContents()
 		{
-			return _text;
+			return SDL_GetClipboardText();
 		}
 
 
 		void IClipboard.setContents( string text )
 		{
-			_text = text;
+			SDL_SetClipboardText(text);
 		}
 
 		#endregion

--- a/Nez.Portable/Nez.csproj
+++ b/Nez.Portable/Nez.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\MonoGame\v3.0\MonoGame.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\MonoGame\v3.0\MonoGame.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -584,5 +585,9 @@
     <Reference Include="MonoGame.Framework">
       <HintPath>..\packages\MonoGame.Framework.Portable.3.6.0.1625\lib\portable-net45+win8+wpa81\MonoGame.Framework.dll</HintPath>
     </Reference>
+    <None Include="$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\DesktopGL\MonoGame.Framework.dll.config">
+      <Link>MonoGame.Framework.dll.config</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Uses the dllmap that monogame uses to define which SDL  library to use for each platform.

Said map that gets linked.
``<?xml version="1.0" encoding="utf-8"?>
<configuration>
	<dllmap dll="SDL2.dll" os="osx" target="libSDL2-2.0.0.dylib"/>
	<dllmap dll="soft_oal.dll" os="osx" target="libopenal.1.dylib" />
	<dllmap dll="SDL2.dll" os="linux" cpu="x86" target="./x86/libSDL2-2.0.so.0"/>
	<dllmap dll="soft_oal.dll" os="linux" cpu="x86" target="./x86/libopenal.so.1" />
	<dllmap dll="SDL2.dll" os="linux" cpu="x86-64" target="./x64/libSDL2-2.0.so.0"/>
	<dllmap dll="soft_oal.dll" os="linux" cpu="x86-64" target="./x64/libopenal.so.1" />
</configuration>``