### PR TITLE
Made it possible to pause particle emission without stopping existing particles, added events to emitter.

### DIFF
--- a/Nez.Portable/ECS/Components/Renderables/Particles/ParticleEmitter.cs
+++ b/Nez.Portable/ECS/Components/Renderables/Particles/ParticleEmitter.cs
@@ -13,7 +13,7 @@ namespace Nez.Particles
 		public bool isPaused { get { return _isPaused; } }
 		public bool isPlaying { get { return _active && !_isPaused; } }
 		public bool isStopped { get { return !_active && !_isPaused; } }
-        public bool isEmitting { get { return _emitting; } }
+		public bool isEmitting { get { return _emitting; } }
 		public float elapsedTime { get { return _elapsedTime; } }
 
 		/// <summary>
@@ -27,15 +27,15 @@ namespace Nez.Particles
 		/// </summary>
 		public ParticleCollisionConfig collisionConfig;
 
-        /// <summary>
-        /// event that's going to be called when particles count becomes 0 after stopping emission.
-        /// emission can stop after either we stop it manually or when we run for entire duration specified in ParticleEmitterConfig.
-        /// </summary>
-        public event Action<ParticleEmitter> onAllParticlesExpired;
-        /// <summary>
-        /// event that's going to be called when emission is stopped due to reaching duration specified in ParticleEmitterConfig
-        /// </summary>
-        public event Action<ParticleEmitter> onEmissionDurationReached;
+		/// <summary>
+		/// event that's going to be called when particles count becomes 0 after stopping emission.
+		/// emission can stop after either we stop it manually or when we run for entire duration specified in ParticleEmitterConfig.
+		/// </summary>
+		public event Action<ParticleEmitter> onAllParticlesExpired;
+		/// <summary>
+		/// event that's going to be called when emission is stopped due to reaching duration specified in ParticleEmitterConfig
+		/// </summary>
+		public event Action<ParticleEmitter> onEmissionDurationReached;
 
 		/// <summary>
 		/// keeps track of how many particles should be emitted
@@ -66,7 +66,7 @@ namespace Nez.Particles
 			_playOnAwake = playOnAwake;
 			_particles = new List<Particle>( (int)_emitterConfig.maxParticles );
 			Pool<Particle>.warmCache( (int)_emitterConfig.maxParticles );
-            
+			
 			// set some sensible defaults
 			collisionConfig.elasticity = 0.5f;
 			collisionConfig.friction = 0.5f;
@@ -114,39 +114,39 @@ namespace Nez.Particles
 			// if the emitter is active and the emission rate is greater than zero then emit particles
 			if( _active && _emitterConfig.emissionRate > 0 )
 			{
-                if( _emitting )
-                {
-                    var rate = 1.0f / _emitterConfig.emissionRate;
+				if( _emitting )
+				{
+					var rate = 1.0f / _emitterConfig.emissionRate;
 
-                    if( _particles.Count < _emitterConfig.maxParticles )
-                        _emitCounter += Time.deltaTime;
+					if( _particles.Count < _emitterConfig.maxParticles )
+						_emitCounter += Time.deltaTime;
 
-                    while( _particles.Count < _emitterConfig.maxParticles && _emitCounter > rate )
-                    {
-                        addParticle( rootPosition );
-                        _emitCounter -= rate;
-                    }
+					while( _particles.Count < _emitterConfig.maxParticles && _emitCounter > rate )
+					{
+						addParticle( rootPosition );
+						_emitCounter -= rate;
+					}
 
-                    _elapsedTime += Time.deltaTime;
+					_elapsedTime += Time.deltaTime;
 
-                    if( _emitterConfig.duration != -1 && _emitterConfig.duration < _elapsedTime )
-                    {
-                        // when we hit our duration we dont emit any more particles
-                        _emitting = false;
+					if( _emitterConfig.duration != -1 && _emitterConfig.duration < _elapsedTime )
+					{
+						// when we hit our duration we dont emit any more particles
+						_emitting = false;
 
-                        if( onEmissionDurationReached != null )
-                            onEmissionDurationReached( this );
-                    }
-                }
+						if( onEmissionDurationReached != null )
+							onEmissionDurationReached( this );
+					}
+				}
 
-                // once all our particles are done we stop the emitter
-                if( _particles.Count == 0 )
-                {
-                    stop();
+				// once all our particles are done we stop the emitter
+				if( _particles.Count == 0 )
+				{
+					stop();
 
-                    if( onAllParticlesExpired != null )
-                        onAllParticlesExpired( this );
-                }
+					if( onAllParticlesExpired != null )
+						onAllParticlesExpired( this );
+				}
 			}
 
 			var min = new Vector2( float.MaxValue, float.MaxValue );
@@ -267,36 +267,36 @@ namespace Nez.Particles
 		{
 			_isPaused = true;
 			_active = false;
-        }
+		}
 
 
-        /// <summary>
-        /// resumes emission of particles.
-        /// this is possible only if stop() wasn't called and emission wasn't stopped due to duration
-        /// </summary>
-        public void resumeEmission()
-        {
-            if( isStopped || ( _emitterConfig.duration != -1 && _emitterConfig.duration < _elapsedTime ) )
-                return;
+		/// <summary>
+		/// resumes emission of particles.
+		/// this is possible only if stop() wasn't called and emission wasn't stopped due to duration
+		/// </summary>
+		public void resumeEmission()
+		{
+			if( isStopped || ( _emitterConfig.duration != -1 && _emitterConfig.duration < _elapsedTime ) )
+				return;
 
-            _emitting = true;
-        }
-
-
-        /// <summary>
-        /// pauses emission of particles while allowing existing particles to expire
-        /// </summary>
-        public void pauseEmission()
-        {
-            _emitting = false;
-        }
+			_emitting = true;
+		}
 
 
-        /// <summary>
-        /// manually emit some particles
-        /// </summary>
-        /// <param name="count">Count.</param>
-        public void emit( int count )
+		/// <summary>
+		/// pauses emission of particles while allowing existing particles to expire
+		/// </summary>
+		public void pauseEmission()
+		{
+			_emitting = false;
+		}
+
+
+		/// <summary>
+		/// manually emit some particles
+		/// </summary>
+		/// <param name="count">Count.</param>
+		public void emit( int count )
 		{
 			var rootPosition = entity.transform.position + _localOffset;
 

--- a/Nez.Portable/ECS/Components/Renderables/Particles/ParticleEmitter.cs
+++ b/Nez.Portable/ECS/Components/Renderables/Particles/ParticleEmitter.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
-using System.Collections.Generic;
 using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
 
 
 namespace Nez.Particles
@@ -12,6 +13,7 @@ namespace Nez.Particles
 		public bool isPaused { get { return _isPaused; } }
 		public bool isPlaying { get { return _active && !_isPaused; } }
 		public bool isStopped { get { return !_active && !_isPaused; } }
+        public bool isEmitting { get { return _emitting; } }
 		public float elapsedTime { get { return _elapsedTime; } }
 
 		/// <summary>
@@ -24,6 +26,16 @@ namespace Nez.Particles
 		/// config object with various properties to deal with particle collisions
 		/// </summary>
 		public ParticleCollisionConfig collisionConfig;
+
+        /// <summary>
+        /// event that's going to be called when particles count becomes 0 after stopping emission.
+        /// emission can stop after either we stop it manually or when we run for entire duration specified in ParticleEmitterConfig.
+        /// </summary>
+        public event Action<ParticleEmitter> onAllParticlesExpired;
+        /// <summary>
+        /// event that's going to be called when emission is stopped due to reaching duration specified in ParticleEmitterConfig
+        /// </summary>
+        public event Action<ParticleEmitter> onEmissionDurationReached;
 
 		/// <summary>
 		/// keeps track of how many particles should be emitted
@@ -54,7 +66,7 @@ namespace Nez.Particles
 			_playOnAwake = playOnAwake;
 			_particles = new List<Particle>( (int)_emitterConfig.maxParticles );
 			Pool<Particle>.warmCache( (int)_emitterConfig.maxParticles );
-
+            
 			// set some sensible defaults
 			collisionConfig.elasticity = 0.5f;
 			collisionConfig.friction = 0.5f;
@@ -102,28 +114,39 @@ namespace Nez.Particles
 			// if the emitter is active and the emission rate is greater than zero then emit particles
 			if( _active && _emitterConfig.emissionRate > 0 )
 			{
-				var rate = 1.0f / _emitterConfig.emissionRate;
+                if( _emitting )
+                {
+                    var rate = 1.0f / _emitterConfig.emissionRate;
 
-				if( _particles.Count < _emitterConfig.maxParticles )
-					_emitCounter += Time.deltaTime;
+                    if( _particles.Count < _emitterConfig.maxParticles )
+                        _emitCounter += Time.deltaTime;
 
-				while( _emitting && _particles.Count < _emitterConfig.maxParticles && _emitCounter > rate )
-				{
-					addParticle( rootPosition );
-					_emitCounter -= rate;
-				}
+                    while( _particles.Count < _emitterConfig.maxParticles && _emitCounter > rate )
+                    {
+                        addParticle( rootPosition );
+                        _emitCounter -= rate;
+                    }
 
-				_elapsedTime += Time.deltaTime;
+                    _elapsedTime += Time.deltaTime;
 
-				if( _emitterConfig.duration != -1 && _emitterConfig.duration < _elapsedTime )
-				{
-					// when we hit our duration we dont emit any more particles
-					_emitting = false;
+                    if( _emitterConfig.duration != -1 && _emitterConfig.duration < _elapsedTime )
+                    {
+                        // when we hit our duration we dont emit any more particles
+                        _emitting = false;
 
-					// once all our particles are done we stop the emitter
-					if( _particles.Count == 0 )
-						stop();
-				}
+                        if( onEmissionDurationReached != null )
+                            onEmissionDurationReached( this );
+                    }
+                }
+
+                // once all our particles are done we stop the emitter
+                if( _particles.Count == 0 )
+                {
+                    stop();
+
+                    if( onAllParticlesExpired != null )
+                        onAllParticlesExpired( this );
+                }
 			}
 
 			var min = new Vector2( float.MaxValue, float.MaxValue );
@@ -244,14 +267,36 @@ namespace Nez.Particles
 		{
 			_isPaused = true;
 			_active = false;
-		}
+        }
 
 
-		/// <summary>
-		/// manually emit some particles
-		/// </summary>
-		/// <param name="count">Count.</param>
-		public void emit( int count )
+        /// <summary>
+        /// resumes emission of particles.
+        /// this is possible only if stop() wasn't called and emission wasn't stopped due to duration
+        /// </summary>
+        public void resumeEmission()
+        {
+            if( isStopped || ( _emitterConfig.duration != -1 && _emitterConfig.duration < _elapsedTime ) )
+                return;
+
+            _emitting = true;
+        }
+
+
+        /// <summary>
+        /// pauses emission of particles while allowing existing particles to expire
+        /// </summary>
+        public void pauseEmission()
+        {
+            _emitting = false;
+        }
+
+
+        /// <summary>
+        /// manually emit some particles
+        /// </summary>
+        /// <param name="count">Count.</param>
+        public void emit( int count )
 		{
 			var rootPosition = entity.transform.position + _localOffset;
 


### PR DESCRIPTION
Added pauseEmission() and resumeEmission() - they set `_emitting` to false or true. Resuming does have an additional check if stop() was called or duration reached, resulting in early return without change of value.

I added those methods because I couldn't find a way to stop emission while updating existing particles (not counting changing ParticleEmitterConfig.emissionRate to 0, because this is going to cause issues when using the same config across several emitters, especially if we want to pause only some of them).

Added isEmitting property - with addition of pausing and resuming emission, access to `_emitting` is going to be useful.


Added events are onAllParticlesExpired (called when particle count reaches 0) and onEmissionDurationReached (called when emission is stopped due to duration).

As a result of those changes, I had to modify IUpdatable.update()


I did some test and I couldn't find any issues.