### PR TITLE
Made Sprite originNormalized and setOriginNormalized scale with entity.transform.scale

### DIFF
--- a/Nez.Portable/ECS/Components/Renderables/Sprites/Sprite.cs
+++ b/Nez.Portable/ECS/Components/Renderables/Sprites/Sprite.cs
@@ -41,8 +41,8 @@ namespace Nez.Sprites
 		/// <value>The origin normalized.</value>
 		public Vector2 originNormalized
 		{
-			get { return new Vector2( _origin.X / width, _origin.Y / height ); }
-			set { setOrigin( new Vector2( value.X * width, value.Y * height ) ); }
+			get { return new Vector2( _origin.X / width * entity.transform.scale.X, _origin.Y / height * entity.transform.scale.Y ); }
+			set { setOrigin( new Vector2( value.X * width / entity.transform.scale.X, value.Y * height / entity.transform.scale.Y ) ); }
 		}
 
 		/// <summary>
@@ -152,7 +152,7 @@ namespace Nez.Sprites
 		/// <param name="origin">Origin.</param>
 		public Sprite setOriginNormalized( Vector2 value )
 		{
-			setOrigin( new Vector2( value.X * width, value.Y * height ) );
+			setOrigin( new Vector2( value.X * width / entity.transform.scale.X, value.Y * height / entity.transform.scale.Y ) );
 			return this;
 		}
 


### PR DESCRIPTION
Without this change, originNormalized feels counter-intuitive to me.

If, for example, I set scale to Vector2(5f, 5f) then if I want to position that Sprite in the center I must use Vector2(0.1f, 0.1f) if I want origin to be in the middle. With this change the center is always going to be position Vector2(0.5f, 0.5f).