### PR TITLE
Fixed ParticleEmitter.onAllParticlesExpired being called when it shouldn't.

### DIFF
--- a/Nez.Portable/ECS/Components/Renderables/Particles/ParticleEmitter.cs
+++ b/Nez.Portable/ECS/Components/Renderables/Particles/ParticleEmitter.cs
@@ -140,7 +140,7 @@ namespace Nez.Particles
 				}
 
 				// once all our particles are done we stop the emitter
-				if( _particles.Count == 0 )
+				if( !_emitting && _particles.Count == 0 )
 				{
 					stop();
 


### PR DESCRIPTION
When testing this happened when ParticleEmitterConfig.maxParticles was small enough (below 100).