### PR TITLE
Use id attribute instead of gid in TiledObject

### DIFF
--- a/Nez.PipelineImporter/Tiled/TiledMapWriter.cs
+++ b/Nez.PipelineImporter/Tiled/TiledMapWriter.cs
@@ -157,7 +157,7 @@ namespace Nez.TiledMaps
 				writer.Write( group.objects.Count );
 				foreach( var obj in group.objects )
 				{
-					writer.Write( obj.gid );
+					writer.Write( obj.id );
 					writer.Write( obj.name ?? string.Empty );
 					writer.Write( obj.type ?? string.Empty );
 					writer.Write( (int)obj.x );

--- a/Nez.PipelineImporter/Tiled/TmxObject.cs
+++ b/Nez.PipelineImporter/Tiled/TmxObject.cs
@@ -7,8 +7,8 @@ namespace Nez.TiledMaps
 {
 	public class TmxObject
 	{
-		[XmlAttribute( DataType = "int", AttributeName = "gid" )]
-		public int gid;
+		[XmlAttribute( DataType = "int", AttributeName = "id" )]
+		public int id;
 
 		[XmlAttribute( DataType = "string", AttributeName = "name" )]
 		public string name;
@@ -30,6 +30,9 @@ namespace Nez.TiledMaps
 
 		[XmlAttribute( DataType = "int", AttributeName = "rotation" )]
 		public int rotation;
+
+	    [XmlAttribute( DataType = "int", AttributeName = "gid" )]
+	    public int gid;
 
 		[XmlAttribute( DataType = "boolean", AttributeName = "visible" )]
 		public bool visible = true;

--- a/Nez.Portable/PipelineRuntime/Tiled/TiledMapReader.cs
+++ b/Nez.Portable/PipelineRuntime/Tiled/TiledMapReader.cs
@@ -217,7 +217,7 @@ namespace Nez.Tiled
 			{
 				var obj = new TiledObject()
 				{
-					gid = reader.ReadInt32(),
+					id = reader.ReadInt32(),
 					name = reader.ReadString(),
 					type = reader.ReadString(),
 					x = reader.ReadInt32(),

--- a/Nez.Portable/PipelineRuntime/Tiled/TiledObject.cs
+++ b/Nez.Portable/PipelineRuntime/Tiled/TiledObject.cs
@@ -16,7 +16,7 @@ namespace Nez.Tiled
 			Polyline
 		}
 
-		public int gid;
+		public int id;
 		public string name;
 		public string type;
 		public int x;


### PR DESCRIPTION
This changes the pipeline to read the correct attribute for getting a TiledObject's unique identifier and corrects the field names because gid has a different meaning in Tiled. 
#387