### PR TITLE
Group transform true by default

### DIFF
--- a/Nez.Portable/UI/Base/Group.cs
+++ b/Nez.Portable/UI/Base/Group.cs
@@ -7,7 +7,7 @@ namespace Nez.UI
 	public class Group : Element, ICullable
 	{
 		internal List<Element> children = new List<Element>();
-		protected bool transform = false;
+		protected bool transform = true;
 		Matrix _previousBatcherTransform;
 		Rectangle? _cullingArea;
 


### PR DESCRIPTION
It fixed a weird bug i had (padding was ignored in some cases)
And looks like it is set to true by default in libGDX too: https://github.com/libgdx/libgdx/blob/master/gdx/src/com/badlogic/gdx/scenes/scene2d/Group.java#L42