### PR TITLE
Fix collision check for rect to circle

### DIFF
--- a/Nez.Portable/Physics/Collisions.cs
+++ b/Nez.Portable/Physics/Collisions.cs
@@ -124,9 +124,9 @@ namespace Nez
 
 		static public bool rectToCircle( float rectX, float rectY, float rectWidth, float rectHeight, Vector2 circleCenter, float radius )
 		{
-			// Check if the circle contains the rectangle's center-point
-			if( Collisions.circleToPoint( circleCenter, radius, new Vector2( rectX + rectWidth / 2, rectY + rectHeight / 2 ) ) )
-				return true;
+		    //Check if the rectangle contains the circle's center-point
+		    if (Collisions.rectToPoint(rectX, rectY, rectWidth, rectHeight, circleCenter))
+		        return true;
 
 			// Check the circle against the relevant edges
 			Vector2 edgeFrom;


### PR DESCRIPTION
This fixes a problem where the Cohen–Sutherland algorithm determines the circle center is inside the rectangle, but the rectangle center may not be in the circle when the rectangle is larger.