### PR TITLE
fix: max gamepad count should be limited to the platform

### DIFF
--- a/Nez.Portable/Input/Input.cs
+++ b/Nez.Portable/Input/Input.cs
@@ -40,7 +40,7 @@ namespace Nez
 			get { return _maxSupportedGamePads; }
 			set
 			{
-				_maxSupportedGamePads = Mathf.clamp( value, 1, 4 );
+				_maxSupportedGamePads = Mathf.clamp( value, 1, GamePad.MaximumGamePadCount );
 				gamePads = new GamePadData[_maxSupportedGamePads];
 				for( var i = 0; i < _maxSupportedGamePads; i++ )
 					gamePads[i] = new GamePadData( (PlayerIndex)i );


### PR DESCRIPTION
Trying to make a 10-player game but when I set Input.maxSupportedGamePads to 10, it would always reset to 4.

Tested with 6 game pads in a cross-platform Monogame project.