### PR TITLE
TextField font parentAlpha fix

### DIFF
--- a/Nez.Portable/UI/Widgets/TextField.cs
+++ b/Nez.Portable/UI/Widgets/TextField.cs
@@ -609,7 +609,7 @@ namespace Nez.UI
 			}
 			else
 			{
-				var col = new Color( fontColor, (int)(fontColor.A * parentAlpha / 255.0f) );
+				var col = new Color( fontColor, (int)(fontColor.A * parentAlpha) );
 				var t = displayText.Substring( visibleTextStart, visibleTextEnd - visibleTextStart );
 				graphics.batcher.drawString( font, t, new Vector2( x + bgLeftWidth + textOffset, y + textY + yOffset ), col );
 			}


### PR DESCRIPTION
as parentAlpha is set to 1 by stage the fonts alpha was messed up. For example setting font color to black turned font invisible and setting font color to orange set the font yellow.