### PR TITLE
TiledIsometericTiledLayer should inherit from TiledTileLayer, not Til…

### DIFF
--- a/Nez.Portable/PipelineRuntime/Tiled/TiledIsometricTiledLayer.cs
+++ b/Nez.Portable/PipelineRuntime/Tiled/TiledIsometricTiledLayer.cs
@@ -6,7 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Nez.Tiled
 {
-	public class TiledIsometricTiledLayer : TiledLayer
+	public class TiledIsometricTiledLayer : TiledTileLayer
 	{
 		public readonly TiledMap tiledMap;
 		public int width;
@@ -20,7 +20,7 @@ namespace Nez.Tiled
 		public int tileHeight { get { return tiledMap.tileHeight; } }
 
 
-		public TiledIsometricTiledLayer( TiledMap map, string name, int width, int height, TiledTile[] tiles ) : base( name )
+		public TiledIsometricTiledLayer( TiledMap map, string name, int width, int height, TiledTile[] tiles ) : base(map, name, width, height)
 		{
 			this.width = width;
 			this.height = height;


### PR DESCRIPTION
The included TIleMapComponent stores the collision layer as a TiledTileLayer, but if in isometric view, this causes an invalid cast.  TiledIsometricTiledLayer should be subclassed from TiledTileLayer.