### PR TITLE
Fixed regression that removed gid from TiledObject

### DIFF
--- a/Nez.PipelineImporter/Tiled/TiledMapWriter.cs
+++ b/Nez.PipelineImporter/Tiled/TiledMapWriter.cs
@@ -165,6 +165,7 @@ namespace Nez.TiledMaps
 					writer.Write( (int)obj.width );
 					writer.Write( (int)obj.height );
 					writer.Write( obj.rotation );
+					writer.Write( obj.gid );
 					writer.Write( obj.visible );
 
 					if( obj.ellipse != null )

--- a/Nez.Portable/PipelineRuntime/Tiled/TiledMapReader.cs
+++ b/Nez.Portable/PipelineRuntime/Tiled/TiledMapReader.cs
@@ -225,6 +225,7 @@ namespace Nez.Tiled
 					width = reader.ReadInt32(),
 					height = reader.ReadInt32(),
 					rotation = reader.ReadInt32(),
+					gid = reader.ReadInt32(),
 					visible = reader.ReadBoolean()
 				};
 

--- a/Nez.Portable/PipelineRuntime/Tiled/TiledObject.cs
+++ b/Nez.Portable/PipelineRuntime/Tiled/TiledObject.cs
@@ -24,6 +24,7 @@ namespace Nez.Tiled
 		public int width;
 		public int height;
 		public int rotation;
+		public int gid;
 		public bool visible;
 		public TiledObjectType tiledObjectType;
 		public string objectType;


### PR DESCRIPTION
I think support for `gid` ("global id") was removed by mistake when someone added the `id` field. The reference to it was still in TmxObject so was just a matter of me adding the missing read/write calls.