### PR TITLE
Avoid caching _componentsToRemove.Count when iterating.

### DIFF
--- a/Nez.Portable/ECS/InternalUtils/ComponentList.cs
+++ b/Nez.Portable/ECS/InternalUtils/ComponentList.cs
@@ -141,7 +141,7 @@ namespace Nez
 			// handle removals
 			if( _componentsToRemove.Count > 0 )
 			{
-				for( int i = 0, count = _componentsToRemove.Count; i < count; i++ )
+				for( int i = 0; i < _componentsToRemove.Count; i++ )
 				{
 					handleRemove( _componentsToRemove[i] );
 					_components.remove( _componentsToRemove[i] );


### PR DESCRIPTION
When removing components, don't cache the initial _componentsToRemove.Count value.  Doing so means that if a component removes another component from the entity, it isn't traversed and later the components to remove list is cleared with the result that the removal is lost.

This allows components to remove other components which allows for a component hierarchy, or to allow components to build upon other components underneath the hood.