### PR TITLE
Add support for importing tile objectgroups

### DIFF
--- a/Nez.PipelineImporter/Tiled/TiledMapWriter.cs
+++ b/Nez.PipelineImporter/Tiled/TiledMapWriter.cs
@@ -43,14 +43,14 @@ namespace Nez.TiledMaps
 			{
 				if( tileset.image != null )
 					TiledMapProcessor.logger.LogMessage( "\nExpecting texture asset: {0}\n", tileset.image.source );
-				
+
 				writer.Write( tileset.isStandardTileset );
 
 				if( tileset.image != null )
 					writer.Write( removeExtension( tileset.image.source ) );
 				else
 					writer.Write( string.Empty );
-				
+
 				writer.Write( tileset.firstGid );
 				writer.Write( tileset.tileWidth );
 				writer.Write( tileset.tileHeight );
@@ -89,6 +89,7 @@ namespace Nez.TiledMaps
 					}
 
 					writeCustomProperties( writer, tile.properties );
+					writeObjectGroups( writer, tile.objectGroups );
 				}
 			}
 
@@ -127,7 +128,7 @@ namespace Nez.TiledMaps
 						writer.Write( tile.flippedDiagonally );
 					}
 
-					writer.Write( tileLayer.width ); 
+					writer.Write( tileLayer.width );
 					writer.Write( tileLayer.height );
 				}
 
@@ -144,10 +145,15 @@ namespace Nez.TiledMaps
 				TiledMapProcessor.logger.LogMessage( "done writing Layer: {0}", layer );
 			}
 
-			writer.Write( map.objectGroups.Count );
-			foreach( var group in map.objectGroups )
+			writeObjectGroups( writer, map.objectGroups );
+		}
+
+		static void writeObjectGroups( ContentWriter writer, List<TmxObjectGroup> objectGroups )
+		{
+			writer.Write( objectGroups.Count );
+			foreach( var group in objectGroups )
 			{
-				writer.Write( group.name );
+				writer.Write( group.name ?? string.Empty );
 				writer.Write( hexToColor( group.color ) );
 				writer.Write( group.visible );
 				writer.Write( group.opacity );
@@ -194,7 +200,7 @@ namespace Nez.TiledMaps
 
 					writeCustomProperties( writer, obj.properties );
 				}
-				
+
 				TiledMapProcessor.logger.LogMessage( "done writing ObjectGroup: {0}", group );
 			}
 		}

--- a/Nez.Portable/PipelineRuntime/Tiled/TiledMap.cs
+++ b/Nez.Portable/PipelineRuntime/Tiled/TiledMap.cs
@@ -123,14 +123,6 @@ namespace Nez.Tiled
 			return layer;
 		}
 
-
-		public TiledObjectGroup createObjectGroup( string name, Color color, bool visible, float opacity )
-		{
-			var group = new TiledObjectGroup( name, color, visible, opacity );
-			objectGroups.Add( group );
-			return group;
-		}
-
 		#endregion
 
 

--- a/Nez.Portable/PipelineRuntime/Tiled/TiledMapReader.cs
+++ b/Nez.Portable/PipelineRuntime/Tiled/TiledMapReader.cs
@@ -82,6 +82,12 @@ namespace Nez.Tiled
 
 					readCustomProperties( reader, tile.properties );
 
+					var tileObjectGroupCount = reader.ReadInt32();
+					if( tileObjectGroupCount > 0 )
+						tile.objectGroups = new List<TiledObjectGroup>( tileObjectGroupCount );
+					for( var k = 0; k < tileObjectGroupCount; k++ )
+						tile.objectGroups.Add( readObjectGroup( reader, tiledMap ) );
+
 					// give the TiledTilesetTile a chance to process and cache any data required
 					tile.processProperties();
 
@@ -102,7 +108,7 @@ namespace Nez.Tiled
 
 			var objectGroupCount = reader.ReadInt32();
 			for( var i = 0; i < objectGroupCount; i++ )
-				readObjectGroup( reader, tiledMap );
+				tiledMap.objectGroups.Add( readObjectGroup( reader, tiledMap ) );
 
 			return tiledMap;
 		}
@@ -206,7 +212,7 @@ namespace Nez.Tiled
 
 		static TiledObjectGroup readObjectGroup( ContentReader reader, TiledMap tiledMap )
 		{
-			var objectGroup = tiledMap.createObjectGroup(
+			var objectGroup = new TiledObjectGroup(
 				reader.ReadString(), reader.ReadColor(), reader.ReadBoolean(), reader.ReadSingle() );
 
 			readCustomProperties( reader, objectGroup.properties );

--- a/Nez.Portable/PipelineRuntime/Tiled/TiledTilesetTile.cs
+++ b/Nez.Portable/PipelineRuntime/Tiled/TiledTilesetTile.cs
@@ -12,6 +12,7 @@ namespace Nez.Tiled
 	{
 		public readonly int id;
 		public readonly TiledMap tiledMap;
+		public List<TiledObjectGroup> objectGroups;
 		public List<TiledTileAnimationFrame> animationFrames;
 		public Dictionary<string, string> properties = new Dictionary<string, string>();
 


### PR DESCRIPTION
As part of the tiled file format, tileset tiles can optionally have a list of objectgroups. https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#tile In the Tiled editor, this is used for adding collision to tiles in the tileset editor, and most of the plumbing for this feature already existed in PipelineImporter, so this PR adds support for writing the tile objectGroups to the compiled xnb file and reading in the Pipeline runtime.