### PR TITLE
Updated imgui version, since the current one doesnt work on mono+linux

### DIFF
--- a/Nez.FarseerPhysics/Nez.FarseerPhysics.DotNetCore.csproj
+++ b/Nez.FarseerPhysics/Nez.FarseerPhysics.DotNetCore.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Nez.FarseerPhysics</AssemblyName>
+    <RootNamespace>Nez.FarseerPhysics</RootNamespace>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Nez.Portable\Nez.DotNetCore.csproj">      
+      <Name>Nez</Name>
+    </ProjectReference>
+    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.0.7"/>
+  </ItemGroup>
+
+</Project>

--- a/Nez.ImGui/Inspectors/SceneGraphPanes/EntityPane.cs
+++ b/Nez.ImGui/Inspectors/SceneGraphPanes/EntityPane.cs
@@ -87,7 +87,7 @@ namespace Nez.ImGuiTools.SceneGraphPanes
 						ImGui.CloseCurrentPopup();
 					}
 					
-					ImGui.SameLine( ImGui.GetContentRegionAvailWidth() - ImGui.GetItemRectSize().X );
+					ImGui.SameLine( ImGui.GetContentRegionAvail().X - ImGui.GetItemRectSize().X );
 
 					ImGui.PushStyleColor( ImGuiCol.Button, Microsoft.Xna.Framework.Color.Green.PackedValue );
 					if( ImGui.Button( "Create" ) )
@@ -122,7 +122,7 @@ namespace Nez.ImGuiTools.SceneGraphPanes
 						ImGui.CloseCurrentPopup();
 					}
 					
-					ImGui.SameLine( ImGui.GetContentRegionAvailWidth() - ImGui.GetItemRectSize().X );
+					ImGui.SameLine( ImGui.GetContentRegionAvail().X - ImGui.GetItemRectSize().X );
 
 					ImGui.PushStyleColor( ImGuiCol.Button, Microsoft.Xna.Framework.Color.Green.PackedValue );
 					if( ImGui.Button( "Create" ) )

--- a/Nez.ImGui/Nez.FNA.ImGui.csproj
+++ b/Nez.ImGui/Nez.FNA.ImGui.csproj
@@ -44,26 +44,26 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<Content Include="$(ImGuiRuntimes)win-x86\native\cimgui.dll" Condition="'$(OS)' == 'Windows_NT' AND '$(Platform)' != 'x64'">
+		<Content Include="$(ImGuiRuntimes)win-x86\native\*.dll" Condition="'$(OS)' == 'Windows_NT' AND '$(Platform)' != 'x64'">
 			<Link>%(Filename)%(Extension)</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
-		<Content Include="$(ImGuiRuntimes)win-x64\native\cimgui.dll" Condition="'$(OS)' == 'Windows_NT' AND '$(Platform)' != 'x86'">
+		<Content Include="$(ImGuiRuntimes)win-x64\native\*.dll" Condition="'$(OS)' == 'Windows_NT' AND '$(Platform)' != 'x86'">
 			<Link>%(Filename)%(Extension)</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
-		<Content Include="$(ImGuiRuntimes)osx-x64\native\cimgui.dylib" Condition="'$(OS)' != 'Windows_NT' AND $(IsOSX) == 'true'">
+		<Content Include="$(ImGuiRuntimes)osx-x64\native\*.dylib" Condition="'$(OS)' != 'Windows_NT' AND $(IsOSX) == 'true'">
 			<Link>libcimgui.dylib</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
-		<Content Include=".$(ImGuiRuntimes)linux-x64\native\cimgui.so" Condition="'$(OS)' != 'Windows_NT' AND $(IsLinux) == 'true'">
+		<Content Include=".$(ImGuiRuntimes)linux-x64\native\*.so" Condition="'$(OS)' != 'Windows_NT' AND $(IsLinux) == 'true'">
 			<Link>%(Filename)%(Extension)</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ImGui.NET" Version="1.67.0" />
+		<PackageReference Include="ImGui.NET" Version="1.71.0" />
 	</ItemGroup>
 	
 	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

--- a/Nez.ImGui/Nez.ImGui.DotNetCore.csproj
+++ b/Nez.ImGui/Nez.ImGui.DotNetCore.csproj
@@ -1,0 +1,50 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Nez.ImGui</RootNamespace>
+	<AssemblyName>Nez.ImGui</AssemblyName>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+	<AllowUnsafeBlocks>true</AllowUnsafeBlocks>	
+  </PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="../Nez.Portable/Nez.DotNetCore.csproj" />
+		<ProjectReference Include="../Nez.Persistence/Nez.Persistence.DotNetCore.csproj" />
+	</ItemGroup>
+
+	<PropertyGroup>
+		<IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
+		<IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+	</PropertyGroup>
+	
+	<!-- Copy ImGui native code to output -->
+	<PropertyGroup>
+		<ImGuiRuntimes>$(NuGetPackageRoot)\imgui.net\**\runtimes\</ImGuiRuntimes>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Content Include="$(ImGuiRuntimes)win-x86\native\cimgui.dll" Condition="'$(OS)' == 'Windows_NT' AND '$(Platform)' != 'x64'">
+			<Link>%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="$(ImGuiRuntimes)win-x64\native\cimgui.dll" Condition="'$(OS)' == 'Windows_NT' AND '$(Platform)' != 'x86'">
+			<Link>%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="$(ImGuiRuntimes)osx-x64\native\cimgui.dylib" Condition="'$(OS)' != 'Windows_NT' AND $(IsOSX) == 'true'">
+			<Link>libcimgui.dylib</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include=".$(ImGuiRuntimes)linux-x64\native\cimgui.so" Condition="'$(OS)' != 'Windows_NT' AND $(IsLinux) == 'true'">
+			<Link>%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
+
+
+  <ItemGroup>
+  	<PackageReference Include="ImGui.NET" Version="1.67.0" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.0.7"/>    
+  </ItemGroup>  
+</Project>

--- a/Nez.ImGui/Nez.ImGui.csproj
+++ b/Nez.ImGui/Nez.ImGui.csproj
@@ -34,26 +34,26 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<Content Include="$(ImGuiRuntimes)win-x86\native\cimgui.dll" Condition="'$(OS)' == 'Windows_NT' AND '$(Platform)' != 'x64'">
+		<Content Include="$(ImGuiRuntimes)win-x86\native\*.dll" Condition="'$(OS)' == 'Windows_NT' AND '$(Platform)' != 'x64'">
 			<Link>%(Filename)%(Extension)</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
-		<Content Include="$(ImGuiRuntimes)win-x64\native\cimgui.dll" Condition="'$(OS)' == 'Windows_NT' AND '$(Platform)' != 'x86'">
+		<Content Include="$(ImGuiRuntimes)win-x64\native\*.dll" Condition="'$(OS)' == 'Windows_NT' AND '$(Platform)' != 'x86'">
 			<Link>%(Filename)%(Extension)</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
-		<Content Include="$(ImGuiRuntimes)osx-x64\native\cimgui.dylib" Condition="'$(OS)' != 'Windows_NT' AND $(IsOSX) == 'true'">
+		<Content Include="$(ImGuiRuntimes)osx-x64\native\*.dylib" Condition="'$(OS)' != 'Windows_NT' AND $(IsOSX) == 'true'">
 			<Link>libcimgui.dylib</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
-		<Content Include=".$(ImGuiRuntimes)linux-x64\native\cimgui.so" Condition="'$(OS)' != 'Windows_NT' AND $(IsLinux) == 'true'">
+		<Content Include=".$(ImGuiRuntimes)linux-x64\native\*.so" Condition="'$(OS)' != 'Windows_NT' AND $(IsLinux) == 'true'">
 			<Link>%(Filename)%(Extension)</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="ImGui.NET" Version="1.67.0" />
+		<PackageReference Include="ImGui.NET" Version="1.71.0" />
 		<PackageReference Include="MonoGame.Framework.Portable" Version="3.7.1.189" />
 	</ItemGroup>
 	

--- a/Nez.ImGui/Utils/NezImGui.cs
+++ b/Nez.ImGui/Utils/NezImGui.cs
@@ -38,7 +38,7 @@ namespace Nez.ImGuiTools
 
 			var min = ImGui.GetItemRectMin();
 			var max = ImGui.GetItemRectMax();
-			max.X = min.X + ImGui.GetContentRegionAvailWidth();
+			max.X = min.X + ImGui.GetContentRegionAvail().X;
 			ImGui.GetWindowDrawList().AddRect( min - minPadding, max + maxPadding, ImGui.ColorConvertFloat4ToU32( color ) );
 
 			// this fits just the content, not the full width
@@ -75,7 +75,7 @@ namespace Nez.ImGuiTools
 		public static void DisableNextWidget( float widgetCustomHeight = 0 )
 		{
 			var origCursorPos = ImGui.GetCursorPos();
-			var widgetSize = new Num.Vector2( ImGui.GetContentRegionAvailWidth(), widgetCustomHeight > 0 ? GetDefaultWidgetHeight() : GetDefaultWidgetHeight() );
+			var widgetSize = new Num.Vector2( ImGui.GetContentRegionAvail().X, widgetCustomHeight > 0 ? GetDefaultWidgetHeight() : GetDefaultWidgetHeight() );
 			ImGui.InvisibleButton( "##disabled", widgetSize );
 			ImGui.SetCursorPos( origCursorPos );
 		}

--- a/Nez.Persistence/Nez.Persistence.DotNetCore.csproj
+++ b/Nez.Persistence/Nez.Persistence.DotNetCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Nez.Persistence</AssemblyName>
+    <RootNamespace>Nez.Persistence</RootNamespace>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+	<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.12.0" />
+  </ItemGroup>
+
+</Project>

--- a/Nez.PipelineImporter/Nez.PipelineImporter.DotNetCore.csproj
+++ b/Nez.PipelineImporter/Nez.PipelineImporter.DotNetCore.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Nez.Portable\Nez.DotNetCore.csproj">      
+      <Name>Nez</Name>
+    </ProjectReference>
+    <PackageReference Include="MonoGame.Framework.Content.Pipeline.Portable" Version="3.7.0.1708"/>
+    <PackageReference Include="Newtonsoft.json" Version="11.0.2"/>
+    <PackageReference Include="MarkerMetro.Unity.Ionic.Zlib" Version="2.0.0.14"/>
+  </ItemGroup>
+
+</Project>

--- a/Nez.PipelineImporter/Nez.PipelineImporter.DotNetCore.csproj
+++ b/Nez.PipelineImporter/Nez.PipelineImporter.DotNetCore.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Reference Include="netstandard" />
     <ProjectReference Include="..\Nez.Portable\Nez.DotNetCore.csproj">      
       <Name>Nez</Name>
     </ProjectReference>

--- a/Nez.Portable/Graphics/Renderers/RenderLayerExcludeRenderer.cs
+++ b/Nez.Portable/Graphics/Renderers/RenderLayerExcludeRenderer.cs
@@ -33,18 +33,18 @@
 			endRender();
 		}
 
-		protected override void debugRender( Scene scene, Camera cam )
-		{
-			Graphics.instance.batcher.end();
-			Graphics.instance.batcher.begin( cam.transformMatrix );
-
-			for( var i = 0; i < scene.renderableComponents.count; i++ )
-			{
-				var renderable = scene.renderableComponents[i];
-				if( !excludedRenderLayers.contains( renderable.renderLayer ) && renderable.enabled && renderable.isVisibleFromCamera( cam ) )
-					renderable.debugRender( Graphics.instance );
-			}
-		}
+//		protected override void debugRender( Scene scene, Camera cam )
+//		{
+//			Graphics.instance.batcher.end();
+//			Graphics.instance.batcher.begin( cam.transformMatrix );
+//
+//			for( var i = 0; i < scene.renderableComponents.count; i++ )
+//			{
+//				var renderable = scene.renderableComponents[i];
+//				if( !excludedRenderLayers.contains( renderable.renderLayer ) && renderable.enabled && renderable.isVisibleFromCamera( cam ) )
+//					renderable.debugRender( Graphics.instance );
+//			}
+//		}
 
 	}
 }

--- a/Nez.Portable/Nez.DotNetCore.csproj
+++ b/Nez.Portable/Nez.DotNetCore.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>    
+    <AssemblyName>Nez</AssemblyName>
+    <RootNamespace>Nez</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="netstandard" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.0.7"/>
+    <PackageReference Include="System.Drawing.Common" Version="4.5.1"/>
+  </ItemGroup>
+
+  <ItemGroup>
+      <None Remove="Content\NezDefaultBMFont.xnb" />
+  </ItemGroup>
+
+  <ItemGroup>
+      <EmbeddedResource Include="Content\NezDefaultBMFont.xnb">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
+    </ItemGroup>
+</Project>

--- a/Nez.Portable/Physics/Shapes/Shape.cs
+++ b/Nez.Portable/Physics/Shapes/Shape.cs
@@ -3,13 +3,12 @@
 
 namespace Nez.PhysicsShapes
 {
-	public abstract class Shape
-	{
+	public abstract class Shape {
 		/// <summary>
 		/// having a separate position field lets us alter the position of the shape for collisions checks as opposed to having to change the
 		/// Entity.position which triggers collider/bounds/hash updates.
 		/// </summary>
-		internal Vector2 position;
+		public Vector2 position;
 
 		/// <summary>
 		/// center is kind of a misnomer. This value isnt necessarily the center of an object. It is more accurately the Collider.localOffset

--- a/Nez.Portable/PipelineRuntime/Tiled/TiledTileLayer.cs
+++ b/Nez.Portable/PipelineRuntime/Tiled/TiledTileLayer.cs
@@ -73,17 +73,17 @@ namespace Nez.Tiled
 			{
 				// we expand our cameraClipBounds by the excess tile width/height of the largest tiles to ensure we include tiles whose
 				// origin might be outside of the cameraClipBounds
-				minX = tiledMap.worldToTilePositionX( cameraClipBounds.left - ( tiledMap.largestTileWidth - tiledMap.tileWidth ) );
-				minY = tiledMap.worldToTilePositionY( cameraClipBounds.top - ( tiledMap.largestTileHeight - tiledMap.tileHeight ) );
-				maxX = tiledMap.worldToTilePositionX( cameraClipBounds.right + ( tiledMap.largestTileWidth - tiledMap.tileWidth ) );
-				maxY = tiledMap.worldToTilePositionY( cameraClipBounds.bottom + ( tiledMap.largestTileHeight - tiledMap.tileHeight ) );
+				minX = tiledMap.worldToTilePositionX((cameraClipBounds.left - ( tiledMap.largestTileWidth - tiledMap.tileWidth ) ) / scale.X);
+				minY = tiledMap.worldToTilePositionY((cameraClipBounds.top - ( tiledMap.largestTileHeight - tiledMap.tileHeight ) ) / scale.Y);
+				maxX = tiledMap.worldToTilePositionX((cameraClipBounds.right + ( tiledMap.largestTileWidth - tiledMap.tileWidth ) ) / scale.X);
+				maxY = tiledMap.worldToTilePositionY((cameraClipBounds.bottom + ( tiledMap.largestTileHeight - tiledMap.tileHeight ) ) / scale.Y);
 			}
 			else
 			{
-				minX = tiledMap.worldToTilePositionX( cameraClipBounds.left );
-				minY = tiledMap.worldToTilePositionY( cameraClipBounds.top );
-				maxX = tiledMap.worldToTilePositionX( cameraClipBounds.right );
-				maxY = tiledMap.worldToTilePositionY( cameraClipBounds.bottom );
+				minX = Mathf.clamp(tiledMap.worldToTilePositionX( cameraClipBounds.left / scale.X), 0, tiledMap.width -1);
+				minY = Mathf.clamp(tiledMap.worldToTilePositionY( cameraClipBounds.top / scale.Y), 0, tiledMap.height -1);
+				maxX = Mathf.clamp(tiledMap.worldToTilePositionX( cameraClipBounds.right / scale.X ), 0, tiledMap.width -1);
+				maxY = Mathf.clamp(tiledMap.worldToTilePositionY( cameraClipBounds.bottom / scale.Y), 0, tiledMap.height -1);
 			}
 
 			// loop through and draw all the non-culled tiles


### PR DESCRIPTION
Basically what the title says - the current imgui version does not work file correctly on linux with mono (https://github.com/mellinoe/ImGui.NET/issues/113). Updating to a next minor version caused another issue, so I just upgraded to the latest available.
As of the the latest version, api method "GetContentRegionAvailWidth" was removed, and the .so and .dylib files were renamed to libcimgui, so I have also changed a bit of code and filenames in copy tasks to asterisks (did that just in case names change again; I can put the exact names back, if you want)