### PR TITLE
Cleaned up usages of WithinEpsilon()

### DIFF
--- a/Nez.Portable/ECS/Components/Text/TextRun.cs
+++ b/Nez.Portable/ECS/Components/Text/TextRun.cs
@@ -242,7 +242,7 @@ namespace Nez
 				float rotationMatrix1Y;
 				float rotationMatrix2X;
 				float rotationMatrix2Y;
-				if (!Mathf.WithinEpsilon(Rotation, 0.0f))
+				if (!Mathf.WithinEpsilon(Rotation))
 				{
 					var sin = Mathf.Sin(Rotation);
 					var cos = Mathf.Cos(Rotation);

--- a/Nez.Portable/Graphics/Batcher/Batcher.cs
+++ b/Nez.Portable/Graphics/Batcher/Batcher.cs
@@ -745,7 +745,7 @@ namespace Nez
 			float rotationMatrix1Y;
 			float rotationMatrix2X;
 			float rotationMatrix2Y;
-			if (!Mathf.WithinEpsilon(rotation, 0))
+			if (!Mathf.WithinEpsilon(rotation))
 			{
 				var sin = Mathf.Sin(rotation);
 				var cos = Mathf.Cos(rotation);
@@ -884,7 +884,7 @@ namespace Nez
 			float rotationMatrix1Y;
 			float rotationMatrix2X;
 			float rotationMatrix2Y;
-			if (!Mathf.WithinEpsilon(rotation, 0))
+			if (!Mathf.WithinEpsilon(rotation))
 			{
 				var sin = Mathf.Sin(rotation);
 				var cos = Mathf.Cos(rotation);

--- a/Nez.Portable/Math/Mathf.cs
+++ b/Nez.Portable/Math/Mathf.cs
@@ -611,11 +611,16 @@ namespace Nez
 			return Round(value / roundToNearest) * roundToNearest;
 		}
 
-
+        /// <summary>
+        /// Checks if the value passed falls under a certain threshold.
+        /// Useful for small, precise comparisons.
+        /// </summary>
+        /// <param name="value">The value to check.</param>
+        /// <param name="ep">The threshold to check the value with. <see cref="Epsilon"/> is used by default.</param>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static bool WithinEpsilon(float floatA, float floatB)
+		public static bool WithinEpsilon(float value, float ep = Epsilon)
 		{
-			return Math.Abs(floatA - floatB) < Epsilon;
+			return Math.Abs(value) < ep;
 		}
 
 


### PR DESCRIPTION
Addresses #501. The second parameter has been changed from another expression that can be passed in to a variable epsilon to compare to, with `Mathf.Epsilon (0.00001f)` being the default. All current usages of the method use 0 as the second parameter, so the current subtraction that's being done is meaningless.