### PR TITLE
Added CurrentFrame field to SpriteAnimator

### DIFF
--- a/Nez.Portable/ECS/Components/Renderables/Sprites/SpriteAnimator.cs
+++ b/Nez.Portable/ECS/Components/Renderables/Sprites/SpriteAnimator.cs
@@ -56,6 +56,11 @@ namespace Nez.Sprites
 		/// </summary>
 		public string CurrentAnimationName => _currentAnimationName;
 
+		/// <summary>
+		/// index of the current frame in sprite array of the current animation
+		/// </summary>
+		public int CurrentFrame { get; private set; }
+
 		readonly Dictionary<string, SpriteAnimation> _animations = new Dictionary<string, SpriteAnimation>();
 		SpriteAnimation _currentAnimation;
 		string _currentAnimationName;
@@ -103,8 +108,8 @@ namespace Nez.Sprites
 			if ((_loopMode == LoopMode.PingPong || _loopMode == LoopMode.PingPongOnce) && completedIterations % 2 != 0)
 				currentElapsed = iterationDuration - currentElapsed;
 
-			var desiredFrame = Mathf.FloorToInt(currentElapsed / secondsPerFrame);
-			Sprite = _currentAnimation.Sprites[desiredFrame];
+			CurrentFrame = Mathf.FloorToInt(currentElapsed / secondsPerFrame);
+			Sprite = _currentAnimation.Sprites[CurrentFrame];
 		}
 
 		/// <summary>


### PR DESCRIPTION
Hi,
Before Sprite<T> refactoring there was a `CurrentFrame` field. This field is essential for animation state machines, for example, jump animation may consist of a non-looped animation followed by a looped animation. In order to do this you can play the first animation, then check current frame in the update method, and if we are at the last frame, switch the animation.