### PR TITLE
SpriteAtlas problems with decimal seperator and origin

### DIFF
--- a/Nez.Portable/Assets/SpriteAtlases/Loader/SpriteAtlasLoader.cs
+++ b/Nez.Portable/Assets/SpriteAtlases/Loader/SpriteAtlasLoader.cs
@@ -53,8 +53,8 @@ namespace Nez.Sprites
 						// origin
 						line = stream.ReadLine();
 						lineParts = line.Split(commaSplitter, StringSplitOptions.RemoveEmptyEntries);
-						var origin = new Vector2(float.Parse(lineParts[0]), float.Parse(lineParts[1]));
-						spriteAtlas.Origins.Add(origin);
+						var origin = new Vector2(float.Parse(lineParts[0], System.Globalization.CultureInfo.InvariantCulture), float.Parse(lineParts[1], System.Globalization.CultureInfo.InvariantCulture));
+						spriteAtlas.Origins.Add(origin * rect.Size.ToVector2());
 					}
 					else
 					{

--- a/Nez.SpriteAtlasPacker/SpriteAtlasPacker/Exporters/AtlasMapExporter.cs
+++ b/Nez.SpriteAtlasPacker/SpriteAtlasPacker/Exporters/AtlasMapExporter.cs
@@ -25,7 +25,7 @@ namespace Nez.Tools.Atlases
 	                 	destination.Y, 
 	                 	destination.Width, 
 	                 	destination.Height,
-						arguments.OriginX, arguments.OriginY );
+                        arguments.OriginX.ToString(System.Globalization.CultureInfo.InvariantCulture), arguments.OriginY.ToString(System.Globalization.CultureInfo.InvariantCulture));
 				}
 
 				if ( animations.Count > 0)


### PR DESCRIPTION
let sprite atlas use international decimal seperator,
multiply origin with actual size of texture