### PR TITLE
Fixed rendering image collection images

### DIFF
--- a/Nez.Portable/Assets/Tiled/Runtime/TiledRendering.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledRendering.cs
@@ -221,18 +221,18 @@ namespace Nez.Tiled
 						pos.Y -= size * 0.5f;
 						batcher.DrawPixel(pos, objGroup.Color, (int)size);
 						goto default;
-                    case TmxObjectType.Tile:
-                        var spriteEffects = SpriteEffects.None;
-                        if (obj.Tile.HorizontalFlip)
-                            spriteEffects |= SpriteEffects.FlipHorizontally;
-                        if (obj.Tile.VerticalFlip)
-                            spriteEffects |= SpriteEffects.FlipVertically;
+					case TmxObjectType.Tile:
+						var spriteEffects = SpriteEffects.None;
+						if (obj.Tile.HorizontalFlip)
+							spriteEffects |= SpriteEffects.FlipHorizontally;
+						if (obj.Tile.VerticalFlip)
+							spriteEffects |= SpriteEffects.FlipVertically;
 
-                        var tileset = objGroup.Map.GetTilesetForTileGid(obj.Tile.Gid);
-                        var sourceRect = tileset.TileRegions[obj.Tile.Gid];
-                        pos.Y -= obj.Tile.TilesetTile.Image.Height;
-                        batcher.Draw(obj.Tile.TilesetTile.Image.Texture, pos, sourceRect, Color.White, 0, Vector2.Zero, scale, spriteEffects, layerDepth);
-                        goto default;
+						var tileset = objGroup.Map.GetTilesetForTileGid(obj.Tile.Gid);
+						var sourceRect = tileset.TileRegions[obj.Tile.Gid];
+						pos.Y -= obj.Tile.TilesetTile.Image.Height;
+						batcher.Draw(obj.Tile.TilesetTile.Image.Texture, pos, sourceRect, Color.White, 0, Vector2.Zero, scale, spriteEffects, layerDepth);
+						goto default;
                     case TmxObjectType.Ellipse:
 						pos = new Vector2(obj.X + obj.Width * 0.5f, obj.Y + obj.Height * 0.5f) * scale;
 						batcher.DrawCircle(pos, obj.Width * 0.5f, objGroup.Color);

--- a/Nez.Portable/Assets/Tiled/Runtime/TiledRendering.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledRendering.cs
@@ -221,21 +221,19 @@ namespace Nez.Tiled
 						pos.Y -= size * 0.5f;
 						batcher.DrawPixel(pos, objGroup.Color, (int)size);
 						goto default;
-					case TmxObjectType.Tile:
-						var tx = obj.Tile.X * objGroup.Map.TileWidth * scale.X;
-						var ty = obj.Tile.Y * objGroup.Map.TileHeight * scale.Y;
+                    case TmxObjectType.Tile:
+                        var spriteEffects = SpriteEffects.None;
+                        if (obj.Tile.HorizontalFlip)
+                            spriteEffects |= SpriteEffects.FlipHorizontally;
+                        if (obj.Tile.VerticalFlip)
+                            spriteEffects |= SpriteEffects.FlipVertically;
 
-						var spriteEffects = SpriteEffects.None;
-						if (obj.Tile.HorizontalFlip)
-							spriteEffects |= SpriteEffects.FlipHorizontally;
-						if (obj.Tile.VerticalFlip)
-							spriteEffects |= SpriteEffects.FlipVertically;
-
-						var tileset = objGroup.Map.GetTilesetForTileGid(obj.Tile.Gid);
-						var sourceRect = tileset.TileRegions[obj.Tile.Gid];
-						batcher.Draw(tileset.Image.Texture, pos, sourceRect, Color.White, 0, Vector2.Zero, scale, spriteEffects, layerDepth);
-						goto default;
-					case TmxObjectType.Ellipse:
+                        var tileset = objGroup.Map.GetTilesetForTileGid(obj.Tile.Gid);
+                        var sourceRect = tileset.TileRegions[obj.Tile.Gid];
+                        pos.Y -= obj.Tile.TilesetTile.Image.Height;
+                        batcher.Draw(obj.Tile.TilesetTile.Image.Texture, pos, sourceRect, Color.White, 0, Vector2.Zero, scale, spriteEffects, layerDepth);
+                        goto default;
+                    case TmxObjectType.Ellipse:
 						pos = new Vector2(obj.X + obj.Width * 0.5f, obj.Y + obj.Height * 0.5f) * scale;
 						batcher.DrawCircle(pos, obj.Width * 0.5f, objGroup.Color);
 						goto default;

--- a/Nez.Portable/Assets/Tiled/Runtime/TiledRendering.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledRendering.cs
@@ -233,7 +233,7 @@ namespace Nez.Tiled
 						pos.Y -= obj.Tile.TilesetTile.Image.Height;
 						batcher.Draw(obj.Tile.TilesetTile.Image.Texture, pos, sourceRect, Color.White, 0, Vector2.Zero, scale, spriteEffects, layerDepth);
 						goto default;
-                    case TmxObjectType.Ellipse:
+					case TmxObjectType.Ellipse:
 						pos = new Vector2(obj.X + obj.Width * 0.5f, obj.Y + obj.Height * 0.5f) * scale;
 						batcher.DrawCircle(pos, obj.Width * 0.5f, objGroup.Color);
 						goto default;


### PR DESCRIPTION
They were offset.
This PR also contains a small piece of another PR (tileset.Image.Texture -> obj.Tile.TilesetTile.Image.Texture).
Shouldn't break anything.