### PR TITLE
fixed UI Image size not being set

### DIFF
--- a/Nez.Portable/UI/Drawable/SpriteDrawable.cs
+++ b/Nez.Portable/UI/Drawable/SpriteDrawable.cs
@@ -77,7 +77,7 @@ namespace Nez.UI
 
 		public SpriteDrawable(Sprite sprite)
 		{
-			_sprite = sprite;
+			Sprite = sprite;
 		}
 
 		public SpriteDrawable(Texture2D texture) : this(new Sprite(texture))


### PR DESCRIPTION
Image was not rendered because size was not set when SpriteDrawable created from Sprite.