### PR TITLE
Relax GetComponent constraint.

### DIFF
--- a/Nez.Portable/ECS/Entity.cs
+++ b/Nez.Portable/ECS/Entity.cs
@@ -437,7 +437,7 @@ namespace Nez
 		/// </summary>
 		/// <returns>The component.</returns>
 		/// <typeparam name="T">The 1st type parameter.</typeparam>
-		public T GetComponent<T>() where T : Component => Components.GetComponent<T>(false);
+		public T GetComponent<T>() where T : class => Components.GetComponent<T>(false);
 
 		/// <summary>
 		/// Gets the first Component of type T and returns it. If no Component is found the Component will be created.
@@ -460,7 +460,7 @@ namespace Nez
 		/// <returns>The component.</returns>
 		/// <param name="onlyReturnInitializedComponents">If set to <c>true</c> only return initialized components.</param>
 		/// <typeparam name="T">The 1st type parameter.</typeparam>
-		public T GetComponent<T>(bool onlyReturnInitializedComponents) where T : Component
+		public T GetComponent<T>(bool onlyReturnInitializedComponents) where T : class
 		{
 			return Components.GetComponent<T>(onlyReturnInitializedComponents);
 		}
@@ -477,7 +477,7 @@ namespace Nez
 		/// </summary>
 		/// <returns>The component.</returns>
 		/// <typeparam name="T">The 1st type parameter.</typeparam>
-		public List<T> GetComponents<T>() where T : Component => Components.GetComponents<T>();
+		public List<T> GetComponents<T>() where T : class => Components.GetComponents<T>();
 
 		/// <summary>
 		/// removes the first Component of type T from the components list

--- a/Nez.Portable/ECS/InternalUtils/ComponentList.cs
+++ b/Nez.Portable/ECS/InternalUtils/ComponentList.cs
@@ -226,7 +226,7 @@ namespace Nez
 		/// <param name="onlyReturnInitializedComponents">If set to <c>true</c> only return initialized components.</param>
 		/// <typeparam name="T">The 1st type parameter.</typeparam>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public T GetComponent<T>(bool onlyReturnInitializedComponents) where T : Component
+		public T GetComponent<T>(bool onlyReturnInitializedComponents) where T : class
 		{
 			for (var i = 0; i < _components.Length; i++)
 			{


### PR DESCRIPTION
`GetComponent` expects a `Component` but it could expect any class. This is useful for getting components that implement a certain interface. `GetComponents` already expects just a `class`.