### PR TITLE
Fixed false collision result making the first result's collider null.

### DIFF
--- a/Nez.Portable/ECS/Components/Physics/Colliders/Collider.cs
+++ b/Nez.Portable/ECS/Components/Physics/Colliders/Collider.cs
@@ -367,11 +367,12 @@ namespace Nez
 				if (neighbor.IsTrigger)
 					continue;
 
-				if (CollidesWith(neighbor, out result))
+				if (CollidesWith(neighbor, out CollisionResult neighborResult))
 				{
 					// hit. back off our motion and our Shape.position
-					motion -= result.MinimumTranslationVector;
-					Shape.position -= result.MinimumTranslationVector;
+					result = neighborResult;
+					motion -= neighborResult.MinimumTranslationVector;
+					Shape.position -= neighborResult.MinimumTranslationVector;
 					didCollide = true;
 				}
 			}


### PR DESCRIPTION
Even though the first collider was detected, the result outputed by the call was a negative one. (Collider is null)

![image](https://user-images.githubusercontent.com/24371247/72212357-4bdac500-34a8-11ea-810c-2d2e8879317a.png)
