### PR TITLE
Let find object of type return generic list

### DIFF
--- a/Nez.Portable/ECS/InternalUtils/EntityList.cs
+++ b/Nez.Portable/ECS/InternalUtils/EntityList.cs
@@ -279,20 +279,20 @@ namespace Nez
 		/// </summary>
 		/// <returns>The of type.</returns>
 		/// <typeparam name="T">The 1st type parameter.</typeparam>
-		public List<Entity> EntitiesOfType<T>() where T : Entity
+		public List<T> EntitiesOfType<T>() where T : Entity
 		{
-			var list = ListPool<Entity>.Obtain();
+			var list = ListPool<T>.Obtain();
 			for (var i = 0; i < _entities.Length; i++)
 			{
 				if (_entities.Buffer[i] is T)
-					list.Add(_entities.Buffer[i]);
+					list.Add((T)_entities.Buffer[i]);
 			}
 
 			foreach (var entity in _entitiesToAdd)
 			{
 				if (entity is T)
 				{
-					list.Add(entity);
+					list.Add((T)entity);
 				}
 			}
 

--- a/Nez.Portable/ECS/Scene.cs
+++ b/Nez.Portable/ECS/Scene.cs
@@ -1070,7 +1070,7 @@ namespace Nez
 		/// </summary>
 		/// <returns>The of type.</returns>
 		/// <typeparam name="T">The 1st type parameter.</typeparam>
-		public List<Entity> EntitiesOfType<T>() where T : Entity => Entities.EntitiesOfType<T>();
+		public List<T> EntitiesOfType<T>() where T : Entity => Entities.EntitiesOfType<T>();
 
 		/// <summary>
 		/// returns the first enabled loaded component of Type T

--- a/Nez.sln
+++ b/Nez.sln
@@ -1,89 +1,97 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nez", "Nez.Portable\Nez.csproj", "{60B7197D-D0D5-405C-90A2-A56903E9B039}"
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.168
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nez", "Nez.Portable\Nez.csproj", "{60B7197D-D0D5-405C-90A2-A56903E9B039}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nez.FarseerPhysics", "Nez.FarseerPhysics\Nez.FarseerPhysics.csproj", "{CB893B1D-CE04-4492-B957-31CE0DCA6C15}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nez.FarseerPhysics", "Nez.FarseerPhysics\Nez.FarseerPhysics.csproj", "{CB893B1D-CE04-4492-B957-31CE0DCA6C15}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nez.ImGui", "Nez.ImGui\Nez.ImGui.csproj", "{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nez.ImGui", "Nez.ImGui\Nez.ImGui.csproj", "{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nez.Persistence", "Nez.Persistence\Nez.Persistence.csproj", "{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nez.Persistence", "Nez.Persistence\Nez.Persistence.csproj", "{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
-		Debug|x86 = Debug|x86
-		Release|x86 = Release|x86
+		Debug|iPhone = Debug|iPhone
 		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
 		Release|iPhone = Release|iPhone
 		Release|iPhoneSimulator = Release|iPhoneSimulator
-		Debug|iPhone = Debug|iPhone
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|iPhone.Build.0 = Debug|Any CPU
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|x86.Build.0 = Debug|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|Any CPU.Build.0 = Release|Any CPU
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|iPhone.ActiveCfg = Release|Any CPU
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|iPhone.Build.0 = Release|Any CPU
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|x86.Build.0 = Debug|Any CPU
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|x86.ActiveCfg = Release|Any CPU
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|x86.Build.0 = Release|Any CPU
 		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|Any CPU.Build.0 = Release|Any CPU
-		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|x86.Build.0 = Debug|Any CPU
-		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|x86.ActiveCfg = Release|Any CPU
-		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|x86.Build.0 = Release|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|iPhone.Build.0 = Debug|Any CPU
 		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
 		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|x86.Build.0 = Debug|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|Any CPU.Build.0 = Release|Any CPU
 		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|iPhone.ActiveCfg = Release|Any CPU
 		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|iPhone.Build.0 = Release|Any CPU
 		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|x86.ActiveCfg = Release|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|x86.Build.0 = Release|Any CPU
 		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|x86.Build.0 = Debug|Any CPU
-		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|x86.ActiveCfg = Release|Any CPU
-		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|x86.Build.0 = Release|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|iPhone.Build.0 = Debug|Any CPU
 		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
 		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|x86.Build.0 = Debug|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|iPhone.ActiveCfg = Release|Any CPU
 		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|iPhone.Build.0 = Release|Any CPU
 		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|Any CPU.Build.0 = Release|Any CPU
-		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|x86.Build.0 = Debug|Any CPU
-		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|x86.ActiveCfg = Release|Any CPU
-		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|x86.Build.0 = Release|Any CPU
-		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|iPhone.Build.0 = Release|Any CPU
-		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|x86.ActiveCfg = Release|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|x86.Build.0 = Release|Any CPU
+		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Debug|x86.Build.0 = Debug|Any CPU
+		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Release|iPhone.Build.0 = Release|Any CPU
+		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Release|x86.ActiveCfg = Release|Any CPU
+		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3FDE446D-3A13-4C2A-832E-0FEAC579ABED}
 	EndGlobalSection
 EndGlobal

--- a/Nez.sln
+++ b/Nez.sln
@@ -1,97 +1,89 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.168
-MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nez", "Nez.Portable\Nez.csproj", "{60B7197D-D0D5-405C-90A2-A56903E9B039}"
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nez", "Nez.Portable\Nez.csproj", "{60B7197D-D0D5-405C-90A2-A56903E9B039}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nez.FarseerPhysics", "Nez.FarseerPhysics\Nez.FarseerPhysics.csproj", "{CB893B1D-CE04-4492-B957-31CE0DCA6C15}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nez.FarseerPhysics", "Nez.FarseerPhysics\Nez.FarseerPhysics.csproj", "{CB893B1D-CE04-4492-B957-31CE0DCA6C15}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nez.ImGui", "Nez.ImGui\Nez.ImGui.csproj", "{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nez.ImGui", "Nez.ImGui\Nez.ImGui.csproj", "{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nez.Persistence", "Nez.Persistence\Nez.Persistence.csproj", "{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nez.Persistence", "Nez.Persistence\Nez.Persistence.csproj", "{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|iPhone = Debug|iPhone
-		Debug|iPhoneSimulator = Debug|iPhoneSimulator
-		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+		Debug|iPhoneSimulator = Debug|iPhoneSimulator
 		Release|iPhone = Release|iPhone
 		Release|iPhoneSimulator = Release|iPhoneSimulator
-		Release|x86 = Release|x86
+		Debug|iPhone = Debug|iPhone
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|x86.Build.0 = Debug|Any CPU
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|iPhone.ActiveCfg = Release|Any CPU
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|iPhone.Build.0 = Release|Any CPU
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|x86.Build.0 = Debug|Any CPU
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|x86.ActiveCfg = Release|Any CPU
 		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|x86.Build.0 = Release|Any CPU
 		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|x86.Build.0 = Debug|Any CPU
 		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|x86.Build.0 = Debug|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|x86.ActiveCfg = Release|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|x86.Build.0 = Release|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|iPhone.ActiveCfg = Release|Any CPU
 		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|iPhone.Build.0 = Release|Any CPU
 		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|x86.ActiveCfg = Release|Any CPU
-		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|x86.Build.0 = Release|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|iPhone.Build.0 = Debug|Any CPU
 		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|x86.Build.0 = Debug|Any CPU
 		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|x86.Build.0 = Debug|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|x86.ActiveCfg = Release|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|x86.Build.0 = Release|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|iPhone.ActiveCfg = Release|Any CPU
 		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|iPhone.Build.0 = Release|Any CPU
 		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|x86.ActiveCfg = Release|Any CPU
-		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|x86.Build.0 = Release|Any CPU
-		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Debug|x86.Build.0 = Debug|Any CPU
-		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Release|iPhone.Build.0 = Release|Any CPU
-		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Release|x86.ActiveCfg = Release|Any CPU
-		{F8C8A3AD-84FE-4BDA-952F-223B1B3C6BCD}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {3FDE446D-3A13-4C2A-832E-0FEAC579ABED}
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|Any CPU.Build.0 = Release|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|x86.Build.0 = Debug|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|x86.ActiveCfg = Release|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|x86.Build.0 = Release|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|iPhone.Build.0 = Release|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|iPhone.Build.0 = Debug|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Previously when trying to find entity of type in the scene the following not generic which made the following inline statement difficult to read;
````
            controller.Avatar =
                Scene.Entities.EntitiesOfType<Avatar>().FirstOrDefault() != null ?
                (Avatar) Scene.Entities.EntitiesOfType<Avatar>().FirstOrDefault() :
                null;
````

Now we can simply do:

````
            controller.Avatar = Scene.Entities.EntitiesOfType<Avatar>().FirstOrDefault();
````
