### PR TITLE
Fix stencil lighting when camera is moving.

### DIFF
--- a/Nez.Portable/ECS/Components/Renderables/StencilLight.cs
+++ b/Nez.Portable/ECS/Components/Renderables/StencilLight.cs
@@ -117,7 +117,7 @@ namespace Nez
 			if (Power > 0 && IsVisibleFromCamera(camera))
 			{
 				_lightEffect.ViewProjectionMatrix = camera.ViewProjectionMatrix;
-				_lightEffect.LightPosition = Entity.Transform.Position;
+				_lightEffect.LightPosition = camera.WorldToScreenPoint(Entity.Transform.Position);
 				_lightEffect.Color = Color * Power;
 
 				batcher.DrawRect(Bounds, Color.White);


### PR DESCRIPTION
Shader wants light position in screen space coordinates so we pass those.
Stops the light glow radius from moving away from the actual source as the
camera moves.