### PR TITLE
Refactored EffectResource.cs

### DIFF
--- a/Nez.Portable/Graphics/Effects/EffectResource.cs
+++ b/Nez.Portable/Graphics/Effects/EffectResource.cs
@@ -57,7 +57,7 @@ namespace Nez
 		internal static byte[] SquaresTransitionBytes => GetFileResourceBytes("Content/nez/effects/transitions/Squares.mgfxo");
 
 		// sprite or post processor effects
-		internal static byte[] SpriteEffectBytes => GetMonoGameEmbeddedResourceBytes("Microsoft.Xna.Framework.Graphics.Effect.Resources.SpriteEffect.ogl.mgfxo");
+		internal static byte[] SpriteEffectBytes => GetMonoGameEmbeddedResourceBytes("Microsoft.Xna.Framework.Platform.Graphics.Effect.Resources.SpriteEffect.ogl.mgfxo");
 
 		internal static byte[] MultiTextureOverlayBytes => GetFileResourceBytes("Content/nez/effects/MultiTextureOverlay.mgfxo");
 


### PR DESCRIPTION
Since [8d46b78@MonoGame](https://github.com/MonoGame/MonoGame/commit/8d46b78c7003ae273825daa3a5aad30bd3c576f0) some files have been moved.

This PR fixes the path wrong in EffectResource.cs