### PR TITLE
Scene will call UpdatePolicyScaler on orientation change

### DIFF
--- a/Nez.Portable/ECS/Scene.cs
+++ b/Nez.Portable/ECS/Scene.cs
@@ -366,6 +366,7 @@ namespace Nez
 			if (EntityProcessors != null)
 				EntityProcessors.Begin();
 			Core.Emitter.AddObserver(CoreEvents.GraphicsDeviceReset, OnGraphicsDeviceReset);
+			Core.Emitter.AddObserver(CoreEvents.OrientationChanged, OnOrientationChanged);
 
 			_didSceneBegin = true;
 			OnStart();
@@ -545,6 +546,7 @@ namespace Nez
 		}
 
 		void OnGraphicsDeviceReset() => UpdateResolutionScaler();
+		void OnOrientationChanged() => UpdateResolutionScaler();
 
 		#endregion
 


### PR DESCRIPTION
This prevents the scene from maintaining its orientation when the device orientation changes.

Without this change, if the device is in e.g. Portrait, and orients to Landscape, the scene keeps
filling the Portrait part of the screen.