### PR TITLE
fix large tile detection

### DIFF
--- a/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
@@ -58,18 +58,7 @@ namespace Nez.Tiled
 				var tileset = ParseTmxTileset(map, e, map.TmxDirectory);
 				map.Tilesets.Add(tileset);
 
-				// we have to iterate the dictionary because tile.gid (the key) could be any number in any order
-				foreach (var kvPair in tileset.Tiles)
-				{
-					var tile = kvPair.Value;
-					if (tile.Image != null)
-					{
-						if (tile.Image.Width > map.MaxTileWidth)
-							map.MaxTileWidth = tile.Image.Width;
-						if (tile.Image.Height > map.MaxTileHeight)
-							map.MaxTileHeight = tile.Image.Height;
-					}
-				}
+				UpdateMaxTileSizes(tileset);
 			}
 
 			map.Layers = new TmxList<ITmxLayer>();
@@ -82,6 +71,29 @@ namespace Nez.Tiled
 
 			return map;
 		}
+
+		private static void UpdateMaxTileSizes(TmxTileset tileset) {
+	        // we have to iterate the dictionary because tile.gid (the key) could be any number in any order
+	        foreach (var kvPair in tileset.Tiles) {
+		        var tile = kvPair.Value;
+		        if (tile.Image != null) {
+			        if (tile.Image.Width > tileset.Map.MaxTileWidth)
+				        tileset.Map.MaxTileWidth = tile.Image.Width;
+			        if (tile.Image.Height > tileset.Map.MaxTileHeight)
+				        tileset.Map.MaxTileHeight = tile.Image.Height;
+		        }
+	        }
+
+	        foreach (var kvPair in tileset.TileRegions) {
+		        var region = kvPair.Value;
+		        var width = (int) region.Width;
+		        var height = (int) region.Height;
+		        if (width > tileset.Map.MaxTileWidth)
+			        tileset.Map.MaxTileWidth = width;
+		        if (width > tileset.Map.MaxTileHeight)
+			        tileset.Map.MaxTileHeight = height;
+	        }
+        }
 
 		static OrientationType ParseOrientationType(string type)
 		{


### PR DESCRIPTION
- recent tiled versions by default do not add `tile` elements to the tileset.
- in those cases, we can check the `TileRegion` sizes to check tile sizes.
- if you create a fresh map in a recent tiled version, and add a tileset with a larger tile size, Nez will not pick up on the larger tile sizes. this patch solves that.