### PR TITLE
add HasComponent to ComponentExt

### DIFF
--- a/Nez.Portable/Utils/Extensions/ComponentExt.cs
+++ b/Nez.Portable/Utils/Extensions/ComponentExt.cs
@@ -25,6 +25,11 @@ namespace Nez
 		{
 			return self.Entity.GetComponent<T>();
 		}
+		        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool HasComponent<T>(this Component self) where T : Component {
+	        return self.Entity.HasComponent<T>();
+        }
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void GetComponents<T>(this Component self, List<T> componentList) where T : class


### PR DESCRIPTION
`HasComponent` exists in `Entity`, and a lot of its analogous methods exist in `ComponentExt`. `HasComponent` was missing, so I added it.