### PR TITLE
revert #576

### DIFF
--- a/Nez.Portable/Utils/Extensions/ComponentExt.cs
+++ b/Nez.Portable/Utils/Extensions/ComponentExt.cs
@@ -25,11 +25,6 @@ namespace Nez
 		{
 			return self.Entity.GetComponent<T>();
 		}
-		        
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool HasComponent<T>(this Component self) where T : Component {
-	        return self.Entity.HasComponent<T>();
-        }
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void GetComponents<T>(this Component self, List<T> componentList) where T : class


### PR DESCRIPTION
Nez cannot be compiled after the commit, so this commit reverts it.

Note: `Entity` doesn't have `HasComponent` method. It might have been an extension method in a local project.