### PR TITLE
Ensure frame order when packing a sprite atlas

### DIFF
--- a/Nez.SpriteAtlasPacker/SpriteAtlasPacker/SpriteAtlasPacker.cs
+++ b/Nez.SpriteAtlasPacker/SpriteAtlasPacker/SpriteAtlasPacker.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Linq;
 
 namespace Nez.Tools.Atlases
 {
@@ -135,7 +136,7 @@ namespace Nez.Tools.Atlases
 		static void FindImagesRecursively(string dir, List<string> images, Dictionary<string, List<string>> animations, bool createAnimations)
 		{
 			var animationFrames = new List<string>();
-			foreach (var file in Directory.GetFiles(dir))
+			foreach (var file in Directory.GetFiles(dir).OrderBy(_ => _))
 			{
 				if (MiscHelper.IsImageFile(file))
 				{


### PR DESCRIPTION
When packing a sprite atlas, with frames: `000.png, 001.png, 003.png...` I end up with a random animation order. I looked around, and as far as I can see, there's no way to explicitly influence the frame order. It looks like it depends only on the order returned by `Directory.GetFiles`. 

I'm guessing this is an implementation detail between e.g. .NET and Mono, or Win/Unix. Adding this OrderBy statement ensures the order, even if the runtime does not return ordered results.

(I'm noticing the issue on macOS + Mono 6.8 )