### PR TITLE
Fix a null argument check

### DIFF
--- a/Nez.Portable/UI/Widgets/Image.cs
+++ b/Nez.Portable/UI/Widgets/Image.cs
@@ -46,7 +46,7 @@ namespace Nez.UI
 		{
 			if (_drawable != drawable)
 			{
-				if (_drawable != null)
+				if (drawable != null)
 				{
 					if (PreferredWidth != drawable.MinWidth || PreferredHeight != drawable.MinHeight)
 						InvalidateHierarchy();


### PR DESCRIPTION
Since `Image.SetDrawable` modifies `drawable`, it should check `drawable` for being null, not `_drawable`.