### PR TITLE
make CollisionLayer and TiledMap settable

### DIFF
--- a/Nez.Portable/ECS/Components/Physics/TiledMapMover.cs
+++ b/Nez.Portable/ECS/Components/Physics/TiledMapMover.cs
@@ -105,12 +105,12 @@ namespace Nez.Tiled
 		/// <summary>
 		/// the TiledTileLayer used for collision checks
 		/// </summary>
-		public readonly TmxLayer CollisionLayer;
+		public TmxLayer CollisionLayer;
 
 		/// <summary>
 		/// the TiledMap that contains collisionLayer
 		/// </summary>
-		public readonly TmxMap TiledMap;
+		public TmxMap TiledMap;
 
 		/// <summary>
 		/// temporary storage for all the tiles that intersect the bounds being checked


### PR DESCRIPTION
make the `CollisionLayer` and `Map` settable fields mirroring those in [TiledMapRenderer](https://github.com/prime31/Nez/blob/master/Nez.Portable/ECS/Components/Renderables/TiledMapRenderer.cs#L22), as requested by #591 