### PR TITLE
594 fix tile rendering when no layers provided

### DIFF
--- a/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
@@ -158,8 +158,9 @@ namespace Nez.Tiled
 				{
 					var xDocTileset = XDocument.Load(stream);
 
-					var tileset = new TmxTileset().LoadTmxTileset(map, xDocTileset.Element("tileset"), firstGid, tmxDir);
-					tileset.TmxDirectory = Path.GetDirectoryName(source);
+					string tsxDir = Path.GetDirectoryName(source);
+					var tileset = new TmxTileset().LoadTmxTileset(map, xDocTileset.Element("tileset"), firstGid, tsxDir);
+					tileset.TmxDirectory = tsxDir;
 
 					return tileset;
 				}

--- a/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
@@ -537,7 +537,7 @@ namespace Nez.Tiled
 			return group;
 		}
 
-		public static TmxTileset LoadTmxTileset(this TmxTileset tileset, TmxMap map, XElement xTileset, int firstGid, string tmxDir)
+		public static TmxTileset LoadTmxTileset(this TmxTileset tileset, TmxMap map, XElement xTileset, int firstGid, string tsxDir)
 		{
 			tileset.Map = map;
 			tileset.FirstGid = firstGid;
@@ -553,7 +553,7 @@ namespace Nez.Tiled
 
 			var xImage = xTileset.Element("image");
 			if (xImage != null)
-				tileset.Image = new TmxImage().LoadTmxImage(xImage, tmxDir);
+				tileset.Image = new TmxImage().LoadTmxImage(xImage, tsxDir);
 
 			var xTerrainType = xTileset.Element("terraintypes");
 			if (xTerrainType != null)
@@ -566,7 +566,7 @@ namespace Nez.Tiled
 			tileset.Tiles = new Dictionary<int, TmxTilesetTile>();
 			foreach (var xTile in xTileset.Elements("tile"))
 			{
-				var tile = new TmxTilesetTile().LoadTmxTilesetTile(tileset, xTile, tileset.Terrains, tmxDir);
+				var tile = new TmxTilesetTile().LoadTmxTilesetTile(tileset, xTile, tileset.Terrains, tsxDir);
 				tileset.Tiles[tile.Id] = tile;
 			}
 

--- a/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
@@ -158,9 +158,8 @@ namespace Nez.Tiled
 				{
 					var xDocTileset = XDocument.Load(stream);
 
-					string tsxDir = Path.GetDirectoryName(source);
-					var tileset = new TmxTileset().LoadTmxTileset(map, xDocTileset.Element("tileset"), firstGid, tsxDir);
-					tileset.TmxDirectory = tsxDir;
+					var tileset = new TmxTileset().LoadTmxTileset(map, xDocTileset.Element("tileset"), firstGid, tmxDir);
+					tileset.TmxDirectory = Path.GetDirectoryName(source);
 
 					return tileset;
 				}
@@ -537,7 +536,7 @@ namespace Nez.Tiled
 			return group;
 		}
 
-		public static TmxTileset LoadTmxTileset(this TmxTileset tileset, TmxMap map, XElement xTileset, int firstGid, string tsxDir)
+		public static TmxTileset LoadTmxTileset(this TmxTileset tileset, TmxMap map, XElement xTileset, int firstGid, string tmxDir)
 		{
 			tileset.Map = map;
 			tileset.FirstGid = firstGid;
@@ -553,7 +552,7 @@ namespace Nez.Tiled
 
 			var xImage = xTileset.Element("image");
 			if (xImage != null)
-				tileset.Image = new TmxImage().LoadTmxImage(xImage, tsxDir);
+				tileset.Image = new TmxImage().LoadTmxImage(xImage, tmxDir);
 
 			var xTerrainType = xTileset.Element("terraintypes");
 			if (xTerrainType != null)
@@ -566,7 +565,7 @@ namespace Nez.Tiled
 			tileset.Tiles = new Dictionary<int, TmxTilesetTile>();
 			foreach (var xTile in xTileset.Elements("tile"))
 			{
-				var tile = new TmxTilesetTile().LoadTmxTilesetTile(tileset, xTile, tileset.Terrains, tsxDir);
+				var tile = new TmxTilesetTile().LoadTmxTilesetTile(tileset, xTile, tileset.Terrains, tmxDir);
 				tileset.Tiles[tile.Id] = tile;
 			}
 

--- a/Nez.Portable/Assets/Tiled/Runtime/TiledRendering.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledRendering.cs
@@ -16,12 +16,12 @@ namespace Nez.Tiled
 		/// <param name="batcher"></param>
 		/// <param name="scale"></param>
 		/// <param name="layerDepth"></param>
-		public static void RenderMap(TmxMap map, Batcher batcher, Vector2 position, Vector2 scale, float layerDepth)
+		public static void RenderMap(TmxMap map, Batcher batcher, Vector2 position, Vector2 scale, float layerDepth, RectangleF cameraClipBounds)
 		{
 			foreach (var layer in map.Layers)
 			{
 				if (layer is TmxLayer tmxLayer && tmxLayer.Visible)
-					RenderLayer(tmxLayer, batcher, position, scale, layerDepth);
+					RenderLayer(tmxLayer, batcher, position, scale, layerDepth, cameraClipBounds);
 				else if (layer is TmxImageLayer tmxImageLayer && tmxImageLayer.Visible)
 					RenderImageLayer(tmxImageLayer, batcher, position, scale, layerDepth);
 				else if (layer is TmxGroup tmxGroup && tmxGroup.Visible)

--- a/Nez.Portable/Assets/Tiled/Runtime/TiledRendering.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledRendering.cs
@@ -16,6 +16,7 @@ namespace Nez.Tiled
 		/// <param name="batcher"></param>
 		/// <param name="scale"></param>
 		/// <param name="layerDepth"></param>
+		/// <param name="cameraClipBounds"></param>
 		public static void RenderMap(TmxMap map, Batcher batcher, Vector2 position, Vector2 scale, float layerDepth, RectangleF cameraClipBounds)
 		{
 			foreach (var layer in map.Layers)

--- a/Nez.Portable/ECS/Components/Renderables/TiledMapRenderer.cs
+++ b/Nez.Portable/ECS/Components/Renderables/TiledMapRenderer.cs
@@ -124,7 +124,7 @@ namespace Nez
 		{
 			if (LayerIndicesToRender == null)
 			{
-				TiledRendering.RenderMap(TiledMap, batcher, Entity.Transform.Position + _localOffset, Transform.Scale, LayerDepth);
+				TiledRendering.RenderMap(TiledMap, batcher, Entity.Transform.Position + _localOffset, Transform.Scale, LayerDepth, camera.Bounds);
 			}
 			else
 			{


### PR DESCRIPTION
https://github.com/prime31/Nez/issues/594

This fixes a performance hit when not explicitly using SetRenderLayers.  The camera bounds are now passed in as well, just like when you render each layer separately.  

It seems like in other cases in RenderMap and RenderLayer functions in `TiledRendering.cs` , when rendering TmxImageLayer, TmxGroup, TmxObjectGroup we are not passing the camera bounds. Should we be passing the camera.Bounds here as well?

`				else if (layer is TmxImageLayer tmxImageLayer && tmxImageLayer.Visible)
					RenderImageLayer(tmxImageLayer, batcher, position, scale, layerDepth);
				else if (layer is TmxGroup tmxGroup && tmxGroup.Visible)
					RenderGroup(tmxGroup, batcher, position, scale, layerDepth);
				else if (layer is TmxObjectGroup tmxObjGroup && tmxObjGroup.Visible)
					RenderObjectGroup(tmxObjGroup, batcher, position, scale, layerDepth);`