### PR TITLE
Tiledmap position calculations using TiledMapRenderer transform

### DIFF
--- a/Nez.Portable/Assets/Tiled/Runtime/Layer.Runtime.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/Layer.Runtime.cs
@@ -107,10 +107,10 @@ namespace Nez.Tiled
 		/// </summary>
 		public List<TmxLayerTile> GetTilesIntersectingBounds(Rectangle bounds)
 		{
-			var minX = Map.WorldToTilePositionX(bounds.X);
-			var minY = Map.WorldToTilePositionY(bounds.Y);
-			var maxX = Map.WorldToTilePositionX(bounds.Right);
-			var maxY = Map.WorldToTilePositionY(bounds.Bottom);
+			var minX = Map.WorldToTilePositionX(bounds.X-Offset.X);
+			var minY = Map.WorldToTilePositionY(bounds.Y-Offset.Y);
+			var maxX = Map.WorldToTilePositionX(bounds.X+ bounds.Right-Offset.Y);
+			var maxY = Map.WorldToTilePositionY(bounds.Y+bounds.Bottom-Offset.Y);
 
 			var tilelist = ListPool<TmxLayerTile>.Obtain();
 

--- a/Nez.Portable/Assets/Tiled/Runtime/Map.Runtime.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/Map.Runtime.cs
@@ -83,6 +83,13 @@ namespace Nez.Tiled
 
 		#region world/local conversion
 
+		//gets attached to the transform of a TiledMapRenderer when its added.
+		public Func<Transform> GetTransform = () => { return new Transform(null); };
+
+		public Transform RendererTransform
+		{
+			get { return GetTransform(); }
+		}
 		/// <summary>
 		/// converts from world to tile position clamping to the tilemap bounds
 		/// </summary>
@@ -90,7 +97,8 @@ namespace Nez.Tiled
 		/// <param name="pos">Position.</param>
 		public Point WorldToTilePosition(Vector2 pos, bool clampToTilemapBounds = true)
 		{
-			return new Point(WorldToTilePositionX(pos.X, clampToTilemapBounds), WorldToTilePositionY(pos.Y, clampToTilemapBounds));
+			return new Point(WorldToTilePositionX(pos.X, clampToTilemapBounds),
+				WorldToTilePositionY(pos.Y, clampToTilemapBounds));
 		}
 
 		/// <summary>
@@ -100,7 +108,7 @@ namespace Nez.Tiled
 		/// <param name="x">The x coordinate.</param>
 		public int WorldToTilePositionX(float x, bool clampToTilemapBounds = true)
 		{
-			var tileX = Mathf.FastFloorToInt(x / TileWidth);
+			var tileX = Mathf.FastFloorToInt(((x - RendererTransform.LocalPosition.X) / RendererTransform.Scale.X) / TileWidth);
 			if (!clampToTilemapBounds)
 				return tileX;
 			return Mathf.Clamp(tileX, 0, Width - 1);
@@ -113,7 +121,7 @@ namespace Nez.Tiled
 		/// <param name="y">The y coordinate.</param>
 		public int WorldToTilePositionY(float y, bool clampToTilemapBounds = true)
 		{
-			var tileY = Mathf.FloorToInt(y / TileHeight);
+			var tileY = Mathf.FastFloorToInt(((y - RendererTransform.LocalPosition.Y) / RendererTransform.Scale.Y) / TileWidth);
 			if (!clampToTilemapBounds)
 				return tileY;
 			return Mathf.Clamp(tileY, 0, Height - 1);
@@ -131,14 +139,14 @@ namespace Nez.Tiled
 		/// </summary>
 		/// <returns>The to world position x.</returns>
 		/// <param name="x">The x coordinate.</param>
-		public int TileToWorldPositionX(int x) => x * TileWidth;
+		public int TileToWorldPositionX(int x) => (int)(x * TileWidth * RendererTransform.Scale.X + RendererTransform.LocalPosition.X);
 
 		/// <summary>
 		/// converts from tile to world position
 		/// </summary>
 		/// <returns>The to world position y.</returns>
 		/// <param name="y">The y coordinate.</param>
-		public int TileToWorldPositionY(int y) => y * TileHeight;
+		public int TileToWorldPositionY(int y) => (int)(y * TileHeight * RendererTransform.Scale.Y + RendererTransform.LocalPosition.Y);
 
 		#endregion
 

--- a/Nez.Portable/ECS/Components/Renderables/TiledMapRenderer.cs
+++ b/Nez.Portable/ECS/Components/Renderables/TiledMapRenderer.cs
@@ -28,6 +28,7 @@ namespace Nez
 		public TiledMapRenderer(TmxMap tiledMap, string collisionLayerName = null, bool shouldCreateColliders = true)
 		{
 			TiledMap = tiledMap;
+			tiledMap.GetTransform = ()=>Transform;
 			_shouldCreateColliders = shouldCreateColliders;
 
 			if (collisionLayerName != null)
@@ -61,13 +62,13 @@ namespace Nez
 
 		public int GetRowAtWorldPosition(float yPos)
 		{
-			yPos -= Entity.Transform.Position.Y + _localOffset.Y;
+			yPos -= _localOffset.Y;
 			return TiledMap.WorldToTilePositionY(yPos);
 		}
 
 		public int GetColumnAtWorldPosition(float xPos)
 		{
-			xPos -= Entity.Transform.Position.X + _localOffset.X;
+			xPos -= _localOffset.X;
 			return TiledMap.WorldToTilePositionY(xPos);
 		}
 
@@ -78,10 +79,7 @@ namespace Nez
 		{
 			Insist.IsNotNull(CollisionLayer, "collisionLayer must not be null!");
 
-			// offset the passed in world position to compensate for the entity position
-			worldPos -= Entity.Transform.Position + _localOffset;
-
-			return CollisionLayer.GetTileAtWorldPosition(worldPos);
+			return CollisionLayer.GetTileAtWorldPosition(worldPos - _localOffset);
 		}
 
 		/// <summary>
@@ -122,16 +120,12 @@ namespace Nez
 
 		public override void Render(Batcher batcher, Camera camera)
 		{
-			if (LayerIndicesToRender == null)
-			{
-				TiledRendering.RenderMap(TiledMap, batcher, Entity.Transform.Position + _localOffset, Transform.Scale, LayerDepth, camera.Bounds);
-			}
-			else
-			{
-				for (var i = 0; i < TiledMap.Layers.Count; i++)
-				{
+			if (LayerIndicesToRender == null) {
+				TiledRendering.RenderMap(TiledMap, batcher, _localOffset, Transform, LayerDepth, camera.Bounds);
+			} else {
+				for (var i = 0; i < TiledMap.Layers.Count; i++) {
 					if (TiledMap.Layers[i].Visible && LayerIndicesToRender.Contains(i))
-						TiledRendering.RenderLayer(TiledMap.Layers[i], batcher, Entity.Transform.Position + _localOffset, Transform.Scale, LayerDepth, camera.Bounds);
+						TiledRendering.RenderLayer(TiledMap.Layers[i], batcher, _localOffset, Transform, LayerDepth, camera.Bounds);
 				}
 			}
 		}
@@ -139,7 +133,7 @@ namespace Nez
 		public override void DebugRender(Batcher batcher)
 		{
 			foreach (var group in TiledMap.ObjectGroups)
-				TiledRendering.RenderObjectGroup(group, batcher, Entity.Transform.Position + _localOffset, Transform.Scale, LayerDepth);
+				TiledRendering.RenderObjectGroup(group, batcher, _localOffset, Transform, LayerDepth);
 
 			if (_colliders != null)
 			{

--- a/Nez.Portable/ECS/Transform.cs
+++ b/Nez.Portable/ECS/Transform.cs
@@ -246,9 +246,9 @@ namespace Nez
 		Matrix2D _worldToLocalTransform = Matrix2D.Identity;
 		Matrix2D _worldInverseTransform = Matrix2D.Identity;
 
-		Matrix2D _rotationMatrix;
-		Matrix2D _translationMatrix;
-		Matrix2D _scaleMatrix;
+		Matrix2D _rotationMatrix = Matrix2D.Identity;
+		Matrix2D _translationMatrix = Matrix2D.Identity;
+		Matrix2D _scaleMatrix = Matrix2D.Identity;
 
 		Vector2 _position;
 		Vector2 _scale;


### PR DESCRIPTION
- TiledMapRenderer passes in its transformation to map.
- Translations between world to tile position are correct.
- Camera correctly culls scaled up/ shifted transformations from TiledMapRenderer.
- Does not work with rotation.(Too many corner cases).
- Initiate transformation matrices to identity matrix to avoid some matrices becomes zero in some cases.