### PR TITLE
Fix open file on GitHub

### DIFF
--- a/Nez.ImGui/Core/ImGuiManager.cs
+++ b/Nez.ImGui/Core/ImGuiManager.cs
@@ -194,7 +194,9 @@ namespace Nez.ImGuiTools
 					ImGui.MenuItem("Style Editor", null, ref ShowStyleEditor);
 					if (ImGui.MenuItem("Open imgui_demo.cpp on GitHub"))
 					{
-						System.Diagnostics.Process.Start("https://github.com/ocornut/imgui/blob/master/imgui_demo.cpp");
+						var url = "https://github.com/ocornut/imgui/blob/master/imgui_demo.cpp";
+						var startInfo = new System.Diagnostics.ProcessStartInfo(url) { UseShellExecute = true };
+						System.Diagnostics.Process.Start(startInfo);
 					}
 
 					ImGui.Separator();


### PR DESCRIPTION
I'm using .NET Core 3 and the property `UseShellExecute` is set to `false` by default (it's `true` by default in .NET Framework).

You can see it [here](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.useshellexecute?view=netframework-4.8#property-value).

Because of that I had an "Application not found" exception.

With this change it works seemlessly on both framework.