### PR TITLE
Handle infinite loop for tweens

### DIFF
--- a/Nez.Portable/Utils/Tweens/Tween.cs
+++ b/Nez.Portable/Utils/Tweens/Tween.cs
@@ -101,9 +101,14 @@ namespace Nez.Tweens
 			_loopType = loopType;
 			_delayBetweenLoops = delayBetweenLoops;
 
+			// negative for infinite loop, force -1
+			if (loops < 0)
+				loops = -1;
+
 			// double the loop count for ping-pong
 			if (loopType == LoopType.PingPong)
 				loops = loops * 2;
+
 			_loops = loops;
 
 			return this;
@@ -187,7 +192,7 @@ namespace Nez.Tweens
 			// if we have a loopType and we are Complete (meaning we reached 0 or duration) handle the loop.
 			// handleLooping will take any excess elapsedTime and factor it in and call udpateValue if necessary to keep
 			// the tween perfectly accurate.
-			if (_loopType != LoopType.None && _tweenState == TweenState.Complete && _loops > 0)
+			if (_loopType != LoopType.None && _tweenState == TweenState.Complete && _loops != 0)
 				HandleLooping(elapsedTimeExcess);
 
 			var deltaTime = _isTimeScaleIndependent ? Time.UnscaledDeltaTime : Time.DeltaTime;
@@ -385,7 +390,7 @@ namespace Nez.Tweens
 			}
 
 			// if we have loops left to process reset our state back to Running so we can continue processing them
-			if (_loops > 0)
+			if (_loops != 0)
 			{
 				_tweenState = TweenState.Running;
 


### PR DESCRIPTION
This adds the possibility to set the loops count for a tween to infinity. To do it:

```cs
int loops = -1; // any negative number
tween.SetLoops(type, loops);
```

- The loop count will be forced to `-1` if it's negative.
- The loops will be executed while the `_loops` value isn't `0`, just as before.

The [condition for triggering](https://github.com/Drarig29/Nez/blob/db6e7992ac6c9c15e9bffc70a694f92be32eb57e/Nez.Portable/Utils/Tweens/Tween.cs#L386) the `LoopCompleteHandler` remains unchanged, even in Ping-Pong mode:
- First, the loop count is forced to `-1`
- Then, it's multiplied by 2, we have `-2`
- The handler is triggered only when the value is `-4`, which corresponds to the "pong" (loop complete)