### PR TITLE
Default ParticleEmitterConfig Colors 1:1 Sprite

### DIFF
--- a/Nez.Portable/ECS/Components/Renderables/Particles/ParticleEmitterConfig.cs
+++ b/Nez.Portable/ECS/Components/Renderables/Particles/ParticleEmitterConfig.cs
@@ -31,8 +31,8 @@ namespace Nez.Particles
 		public Vector2 Gravity;
 		public float RadialAcceleration, RadialAccelVariance;
 		public float TangentialAcceleration, TangentialAccelVariance;
-		public Color StartColor = Color.White, StartColorVariance = Color.White;
-		public Color FinishColor = Color.Black, FinishColorVariance = Color.Black;
+		public Color StartColor = Color.White, StartColorVariance = Color.Transparent;
+		public Color FinishColor = Color.White, FinishColorVariance = Color.Transparent;
 		public uint MaxParticles;
 		public float StartParticleSize, StartParticleSizeVariance;
 		public float FinishParticleSize, FinishParticleSizeVariance;


### PR DESCRIPTION
Changed the defaults for the color fields inside the config to have no variance at all and to just output the particle with no fading or random colors.

StartColorVariance was (255,255,255,255) so a random color was picked by default, now its (0,0,0,0)
FinishColor was (0,0,0,255) so it would slowly turn black.
FinishColorVariance was (0,0,0,255) so a random alpha was picked by default, now its (0,0,0,0)