### PR TITLE
Add Monogame .NET Standard projects.

### DIFF
--- a/Nez.ImGui/Nez.Monogame.Standard.ImGui.csproj
+++ b/Nez.ImGui/Nez.Monogame.Standard.ImGui.csproj
@@ -1,0 +1,68 @@
+<Project>
+	<PropertyGroup>
+		<BaseIntermediateOutputPath>obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+	</PropertyGroup>
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<OutputType>Library</OutputType>
+		<RootNamespace>Nez.ImGuiTools</RootNamespace>
+		<AssemblyName>Nez.ImGui</AssemblyName>
+        <TargetFramework>netstandard2.0</TargetFramework>
+		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<OutputPath>bin\Release\Monogame</OutputPath>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DefineConstants>TRACE;DEBUG</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DefineConstants></DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
+		<IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+	</PropertyGroup>
+
+
+	<!-- Copy ImGui native code to output -->
+	<PropertyGroup>
+		<ImGuiRuntimes>$(NuGetPackageRoot)\imgui.net\**\runtimes\</ImGuiRuntimes>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Content Include="$(ImGuiRuntimes)win-x86\native\*.dll" Condition="'$(OS)' == 'Windows_NT' AND '$(Platform)' != 'x64'">
+			<Link>%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="$(ImGuiRuntimes)win-x64\native\*.dll" Condition="'$(OS)' == 'Windows_NT' AND '$(Platform)' != 'x86'">
+			<Link>%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="$(ImGuiRuntimes)osx-x64\native\*.dylib" Condition="'$(OS)' != 'Windows_NT' AND $(IsOSX) == 'true'">
+			<Link>libcimgui.dylib</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include=".$(ImGuiRuntimes)linux-x64\native\*.so" Condition="'$(OS)' != 'Windows_NT' AND $(IsLinux) == 'true'">
+			<Link>%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="ImGui.NET" Version="1.70.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\Nez.Persistence\Nez.Monogame.Standard.Persistence.csproj" />
+	  <ProjectReference Include="..\Nez.Portable\Nez.Monogame.Standard.csproj" />
+	</ItemGroup>
+
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+</Project>

--- a/Nez.Persistence/Nez.Monogame.Standard.Persistence.csproj
+++ b/Nez.Persistence/Nez.Monogame.Standard.Persistence.csproj
@@ -1,0 +1,33 @@
+<Project>
+	<PropertyGroup>
+		<BaseIntermediateOutputPath>obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+	</PropertyGroup>
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<OutputType>Library</OutputType>
+		<RootNamespace>Nez.Persistence</RootNamespace>
+		<AssemblyName>Nez.Persistence</AssemblyName>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<OutputPath>bin\Release\Monogame</OutputPath>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DefineConstants>TRACE;DEBUG</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DefineConstants></DefineConstants>
+	</PropertyGroup>
+
+    <PropertyGroup>
+        <DefaultItemExcludes>$(DefaultItemExcludes);Tests\**\*.*</DefaultItemExcludes>
+    </PropertyGroup>
+
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+</Project>

--- a/Nez.Portable/Core.cs
+++ b/Nez.Portable/Core.cs
@@ -121,8 +121,8 @@ namespace Nez
 				if (_instance._scene == null)
 				{
 					_instance._scene = value;
-					_instance._scene.Begin();
 					_instance.OnSceneChanged();
+					_instance._scene.Begin();
 				}
 				else
 				{

--- a/Nez.Portable/Nez.Monogame.Standard.csproj
+++ b/Nez.Portable/Nez.Monogame.Standard.csproj
@@ -1,0 +1,42 @@
+﻿<Project>	
+	<PropertyGroup>
+		<BaseIntermediateOutputPath>obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+	</PropertyGroup>
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <AssemblyName>Nez</AssemblyName>
+    <RootNamespace>Nez</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <DefineConstants>TRACE;DEBUG</DefineConstants>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <DefineConstants></DefineConstants>
+    </PropertyGroup>
+
+    <ItemGroup>
+      	<Compile Remove="Graphics\SVG\Shapes\Paths\SvgPathBuilder.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
+      	<None Remove="Content\NezDefaultBMFont.xnb" />
+    </ItemGroup>
+
+    <ItemGroup>
+      	<EmbeddedResource Include="Content\NezDefaultBMFont.xnb">
+        	<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      	</EmbeddedResource>
+    </ItemGroup>
+	
+	<ItemGroup>
+		<PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
+		<PackageReference Include="System.Drawing.Common" Version="4.5.1" />
+	</ItemGroup>
+
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+</Project>


### PR DESCRIPTION
There are currently project versions for FNA Standard, but not for monogame.
I have added projects for Nez Portable, ImGui and Persistence.
Monogame 3.8 uses .NET Core, and so requires .NET Standard libraries. This will make Nez compatible out-of-the-box.

I also fixed what I consider a bug (although it may be by design...).
When the first scene is loaded, `Scene.Begin()` is called **before** `Core.OnSceneChange()` and for every scene change after, `Scene.Begin()` is called **before** `Core.OnSceneChange()`. This will normally make very little difference, but in some cases it can lead to unexpected behaviour.

For example, if you create a scene, and add the following code inside `OnStart`:
`Core.GetGlobalManager<ImGuiManager>().RegisterDrawCommand(SomeDrawFunction);`

You would expect that the SomeDrawFunction would then be called. But it won't, until you change scene and return to the original scene. This is because of the inconsistent call order of `OnSceneChange()` and `Scene.Begin()`.

