### PR TITLE
Fix debug console

### DIFF
--- a/Nez.ImGui/Nez.Monogame.Standard.ImGui.csproj
+++ b/Nez.ImGui/Nez.Monogame.Standard.ImGui.csproj
@@ -1,0 +1,68 @@
+<Project>
+	<PropertyGroup>
+		<BaseIntermediateOutputPath>obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+	</PropertyGroup>
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<OutputType>Library</OutputType>
+		<RootNamespace>Nez.ImGuiTools</RootNamespace>
+		<AssemblyName>Nez.ImGui</AssemblyName>
+        <TargetFramework>netstandard2.0</TargetFramework>
+		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<OutputPath>bin\Release\Monogame</OutputPath>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DefineConstants>TRACE;DEBUG</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DefineConstants></DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
+		<IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+	</PropertyGroup>
+
+
+	<!-- Copy ImGui native code to output -->
+	<PropertyGroup>
+		<ImGuiRuntimes>$(NuGetPackageRoot)\imgui.net\**\runtimes\</ImGuiRuntimes>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Content Include="$(ImGuiRuntimes)win-x86\native\*.dll" Condition="'$(OS)' == 'Windows_NT' AND '$(Platform)' != 'x64'">
+			<Link>%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="$(ImGuiRuntimes)win-x64\native\*.dll" Condition="'$(OS)' == 'Windows_NT' AND '$(Platform)' != 'x86'">
+			<Link>%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="$(ImGuiRuntimes)osx-x64\native\*.dylib" Condition="'$(OS)' != 'Windows_NT' AND $(IsOSX) == 'true'">
+			<Link>libcimgui.dylib</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include=".$(ImGuiRuntimes)linux-x64\native\*.so" Condition="'$(OS)' != 'Windows_NT' AND $(IsLinux) == 'true'">
+			<Link>%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="ImGui.NET" Version="1.70.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\Nez.Persistence\Nez.Monogame.Standard.Persistence.csproj" />
+	  <ProjectReference Include="..\Nez.Portable\Nez.Monogame.Standard.csproj" />
+	</ItemGroup>
+
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+</Project>

--- a/Nez.Persistence/Nez.Monogame.Standard.Persistence.csproj
+++ b/Nez.Persistence/Nez.Monogame.Standard.Persistence.csproj
@@ -1,0 +1,33 @@
+<Project>
+	<PropertyGroup>
+		<BaseIntermediateOutputPath>obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+	</PropertyGroup>
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<OutputType>Library</OutputType>
+		<RootNamespace>Nez.Persistence</RootNamespace>
+		<AssemblyName>Nez.Persistence</AssemblyName>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<OutputPath>bin\Release\Monogame</OutputPath>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DefineConstants>TRACE;DEBUG</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DefineConstants></DefineConstants>
+	</PropertyGroup>
+
+    <PropertyGroup>
+        <DefaultItemExcludes>$(DefaultItemExcludes);Tests\**\*.*</DefaultItemExcludes>
+    </PropertyGroup>
+
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+</Project>

--- a/Nez.Portable/Assets/BitmapFonts/BitmapFont.cs
+++ b/Nez.Portable/Assets/BitmapFonts/BitmapFont.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.Xna.Framework;
@@ -145,24 +145,35 @@ namespace Nez.BitmapFonts
 		#endregion
 
 		/// <summary>
-		/// Index to get items within thsi collection using array index syntax.
+		/// Index to get items within this collection using array index syntax.
 		/// </summary>
-		public Character this[char character] => Characters[character];
+		public Character this[char character]
+		{
+			get
+			{
+				if (Characters.TryGetValue(character, out var found))
+					return found;
+
+				//Debug.Warn("Failed to find character for '{0}'. Returning '{1}' instead.", character, DefaultCharacter?.Char.ToString() ?? "<null>");
+				return DefaultCharacter;
+			}
+		}
 
 		public void Initialize()
 		{
 			LoadTextures();
-			if (Characters.TryGetValue(' ', out var defaultChar))
+			if (Characters.TryGetValue('?', out var defaultChar))
 			{
 				DefaultCharacter = defaultChar;
 			}
 			else
 			{
-				Debug.Log($"Font {FamilyName} has no space character!");
+				Debug.Log($"Font {FamilyName} has no question mark character! Using 'a' as default character.");
 				DefaultCharacter = this['a'];
 			}
 
-			_spaceWidth = DefaultCharacter.Bounds.Width + DefaultCharacter.XAdvance;
+			var spaceCharacter = Characters[' '];
+			_spaceWidth = spaceCharacter.Bounds.Width + spaceCharacter.XAdvance;
 		}
 
 		/// <summary>

--- a/Nez.Portable/Assets/BitmapFonts/BitmapFontReader.cs
+++ b/Nez.Portable/Assets/BitmapFonts/BitmapFontReader.cs
@@ -71,9 +71,20 @@ namespace Nez.BitmapFonts
                 Padding = new Padding(padLeft, padTop, padRight, padBottom),
                 Characters = characters
             };
-            font.DefaultCharacter = font[' '];
-			font._spaceWidth = font.DefaultCharacter.Bounds.Width + font.DefaultCharacter.XAdvance;
+			
 
+			if (font.Characters.TryGetValue('?', out var defaultChar))
+			{
+				font.DefaultCharacter = defaultChar;
+			}
+			else
+			{
+				Debug.Log($"Font {font.FamilyName} has no question mark character! Using 'a' as default character.");
+				font.DefaultCharacter = font['a'];
+			}
+
+			var spaceCharacter = font.Characters[' '];
+			font._spaceWidth = spaceCharacter.Bounds.Width + spaceCharacter.XAdvance;
 			return font;
 		}
 	}

--- a/Nez.Portable/Core.cs
+++ b/Nez.Portable/Core.cs
@@ -121,8 +121,8 @@ namespace Nez
 				if (_instance._scene == null)
 				{
 					_instance._scene = value;
-					_instance._scene.Begin();
 					_instance.OnSceneChanged();
+					_instance._scene.Begin();
 				}
 				else
 				{

--- a/Nez.Portable/Debug/Debug.cs
+++ b/Nez.Portable/Debug/Debug.cs
@@ -21,6 +21,7 @@ namespace Nez
 		[DebuggerHidden]
 		static void Log(LogType type, string format, params object[] args)
 		{
+			System.Console.WriteLine($"{type}: {string.Format(format, args)}");
 			switch (type)
 			{
 				case LogType.Error:

--- a/Nez.Portable/Nez.Monogame.Standard.csproj
+++ b/Nez.Portable/Nez.Monogame.Standard.csproj
@@ -1,0 +1,42 @@
+﻿<Project>	
+	<PropertyGroup>
+		<BaseIntermediateOutputPath>obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+	</PropertyGroup>
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <AssemblyName>Nez</AssemblyName>
+    <RootNamespace>Nez</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <DefineConstants>TRACE;DEBUG</DefineConstants>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <DefineConstants></DefineConstants>
+    </PropertyGroup>
+
+    <ItemGroup>
+      	<Compile Remove="Graphics\SVG\Shapes\Paths\SvgPathBuilder.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
+      	<None Remove="Content\NezDefaultBMFont.xnb" />
+    </ItemGroup>
+
+    <ItemGroup>
+      	<EmbeddedResource Include="Content\NezDefaultBMFont.xnb">
+        	<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      	</EmbeddedResource>
+    </ItemGroup>
+	
+	<ItemGroup>
+		<PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
+		<PackageReference Include="System.Drawing.Common" Version="4.5.1" />
+	</ItemGroup>
+
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+</Project>


### PR DESCRIPTION
The DebugConsole used a really bad switch statement to detect key input.
It was hard-coded to work with a standard US keyboard layout. If using another keyboard layout, it would not work (added wrong character).
It also didn't allow for smooth typing (holding down a key would only type 1 character).

I've changed it to use Core.Window.TextInput event to get the character that the user actually typed. This makes it work with all keyboard layouts, and whatever keyboard profile the user currently has active.

As far I'm aware, this should work for all supported (desktop) platforms. All console functionality remains intact.

Note, that when typing a character that does not exist in the BitmapFont, the font will throw an exception. This is another bug, for another pull request...