### PR TITLE
Rename GetCustomAttribute to GetAttribute

### DIFF
--- a/Nez.ImGui/Inspectors/TypeInspectors/AbstractTypeInspector.cs
+++ b/Nez.ImGui/Inspectors/TypeInspectors/AbstractTypeInspector.cs
@@ -39,7 +39,7 @@ namespace Nez.ImGuiTools.TypeInspectors
 		/// </summary>
 		public virtual void Initialize()
 		{
-			_tooltip = _memberInfo.GetCustomAttribute<TooltipAttribute>()?.Tooltip;
+			_tooltip = _memberInfo.GetAttribute<TooltipAttribute>()?.Tooltip;
 		}
 
 		/// <summary>

--- a/Nez.ImGui/Inspectors/TypeInspectors/SimpleTypeInspector.cs
+++ b/Nez.ImGui/Inspectors/TypeInspectors/SimpleTypeInspector.cs
@@ -25,7 +25,7 @@ namespace Nez.ImGuiTools.TypeInspectors
 		public override void Initialize()
 		{
 			base.Initialize();
-			_rangeAttribute = _memberInfo.GetCustomAttribute<RangeAttribute>();
+			_rangeAttribute = _memberInfo.GetAttribute<RangeAttribute>();
 
 			// the inspect method name matters! We use reflection to feth it.
 			var valueTypeName = _valueType.Name.ToString();

--- a/Nez.ImGui/Inspectors/TypeInspectors/TypeInspectorUtils.cs
+++ b/Nez.ImGui/Inspectors/TypeInspectors/TypeInspectorUtils.cs
@@ -121,7 +121,7 @@ namespace Nez.ImGuiTools.TypeInspectors
 			var methods = ReflectionUtils.GetMethods(type);
 			foreach (var method in methods)
 			{
-				var attr = method.GetCustomAttribute<T>();
+				var attr = method.GetAttribute<T>();
 				if (attr == null)
 					continue;
 
@@ -160,7 +160,7 @@ namespace Nez.ImGuiTools.TypeInspectors
 				return new TI.ListInspector();
 
 			// check for custom inspectors before checking Nez types in case a subclass implemented one
-			var customInspectorType = valueType.GetTypeInfo().GetCustomAttribute<CustomInspectorAttribute>();
+			var customInspectorType = valueType.GetTypeInfo().GetAttribute<CustomInspectorAttribute>();
 			if (customInspectorType != null)
 			{
 				if (customInspectorType.InspectorType.GetTypeInfo().IsSubclassOf(abstractTypeInspectorType))

--- a/Nez.Portable/Utils/Extensions/MemberInfoExt.cs
+++ b/Nez.Portable/Utils/Extensions/MemberInfoExt.cs
@@ -13,7 +13,7 @@ namespace Nez
 		/// <param name="self"></param>
 		/// <typeparam name="T"></typeparam>
 		/// <returns></returns>
-		public static T GetCustomAttribute<T>(this MemberInfo self) where T : Attribute
+		public static T GetAttribute<T>(this MemberInfo self) where T : Attribute
 		{
 			var attributes = self.GetCustomAttributes(typeof(T));
 			foreach (var attribute in attributes)

--- a/Nez.Portable/Utils/ReflectionUtils.cs
+++ b/Nez.Portable/Utils/ReflectionUtils.cs
@@ -195,7 +195,7 @@ namespace Nez
 			{
 				foreach (var type in assembly.GetTypes())
 				{
-					if (type.GetCustomAttribute<T>() != null)
+					if (type.GetAttribute<T>() != null)
 						typeList.Add(type);
 				}
 			}


### PR DESCRIPTION
When using `Nez` and `System.Reflection` in project files, compiler cannot disambiguate between the two definitions of `GetCustomAttribute<T>`. Rename the `Nez` definition to avoid collisions.