### PR TITLE
Atlas packer line endings consistency; maps customization

### DIFF
--- a/Nez.SpriteAtlasPacker/SpriteAtlasPacker.Console/ProgramArguments.cs
+++ b/Nez.SpriteAtlasPacker/SpriteAtlasPacker.Console/ProgramArguments.cs
@@ -49,6 +49,15 @@ namespace Nez.Tools.Atlases.Console
 		[Argument( ArgumentType.AtMostOnce, ShortName = "", HelpText = "Output LOVE2D lua file" )]
 		public bool lua;
 
+		[Argument(ArgumentType.AtMostOnce, ShortName = "", HelpText = "Write images relative paths instead of just names when building the maps.")]
+		public bool writePaths;
+
+		[Argument(ArgumentType.AtMostOnce, ShortName = "", HelpText = "The map will use LF (\\n) for line endings instead of CRLF (\\r\\n).")]
+		public bool lf;
+
+		[Argument(ArgumentType.AtMostOnce, ShortName = "", HelpText = "The origins of the images won't be written in the map.")]
+		public bool noOrigins;
+
 		private ProgramArguments() { }
 
 		public static ProgramArguments Parse(params string[] args)
@@ -75,7 +84,10 @@ namespace Nez.Tools.Atlases.Console
 				OriginY = originY,
 				FrameRate = fps,
 				InputPaths = input,
-				OutputLua = lua
+				OutputLua = lua,
+				WritePaths = writePaths,
+				LF = lf,
+				NoOrigins = noOrigins
 			};
 		}
 	}

--- a/Nez.SpriteAtlasPacker/SpriteAtlasPacker/Exporters/AtlasMapExporter.cs
+++ b/Nez.SpriteAtlasPacker/SpriteAtlasPacker/Exporters/AtlasMapExporter.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 
 namespace Nez.Tools.Atlases
 {
@@ -8,27 +9,47 @@ namespace Nez.Tools.Atlases
 	{
 		public static string MapExtension => "lua";
 
-		public static void Save(string filename, Dictionary<string, Rectangle> map, Dictionary<string, List<string>> animations, SpriteAtlasPacker.Config arguments )
+		public static void Save(string filename, Dictionary<string, Rectangle> map, Dictionary<string, List<string>> animations, SpriteAtlasPacker.Config arguments)
 		{
-			var images = new List<string>( map.Keys);
+			var images = new List<string>(map.Keys);
+
+			IDictionary<string, string> imagesNames;
+			if (arguments.WritePaths)
+			{
+				string commonPath = MiscHelper.GetCommonPath(images);
+				imagesNames = images.ToDictionary(k => k, v => v.Substring(commonPath.Length));
+			}
+			else
+			{
+				imagesNames = images.ToDictionary(k => k, v => Path.GetFileNameWithoutExtension(v));
+			}
+
 			using (var writer = new StreamWriter(filename))
 			{
+				writer.NewLine = arguments.LF ? "\n" : "\r\n";
+
 				foreach (var image in images)
 				{
-					// get the destination rectangle
-					var destination = map[image];
+					writer.WriteLine(imagesNames[image]);
 
 					// write out the destination rectangle for this bitmap
-					writer.WriteLine("{0}\n\t{1},{2},{3},{4}\n\t{5},{6}", 
-	                 	Path.GetFileNameWithoutExtension(image), 
-	                 	destination.X, 
-	                 	destination.Y, 
-	                 	destination.Width, 
-	                 	destination.Height,
-                        arguments.OriginX.ToString(System.Globalization.CultureInfo.InvariantCulture), arguments.OriginY.ToString(System.Globalization.CultureInfo.InvariantCulture));
+					var destination = map[image];
+					writer.WriteLine("\t{0},{1},{2},{3}",
+						destination.X,
+						destination.Y,
+						destination.Width,
+						destination.Height);
+
+					// write images origins
+					if (!arguments.NoOrigins)
+					{
+						writer.WriteLine("\t{0},{1}",
+							arguments.OriginX.ToString(System.Globalization.CultureInfo.InvariantCulture),
+							arguments.OriginY.ToString(System.Globalization.CultureInfo.InvariantCulture));
+					}
 				}
 
-				if ( animations.Count > 0)
+				if (animations.Count > 0)
 				{
 					writer.WriteLine();
 
@@ -47,6 +68,6 @@ namespace Nez.Tools.Atlases
 				}
 			}
 		}
-	
+
 	}
 }

--- a/Nez.SpriteAtlasPacker/SpriteAtlasPacker/Exporters/LuaMapExporter.cs
+++ b/Nez.SpriteAtlasPacker/SpriteAtlasPacker/Exporters/LuaMapExporter.cs
@@ -14,6 +14,8 @@ namespace Nez.Tools.Atlases
 			var images = ImagesNotInAnimations(map.Keys.ToArray(), animations);
 			using (var writer = new StreamWriter(filename))
 			{
+				writer.NewLine = arguments.LF ? "\n" : "\r\n";
+
 				writer.WriteLine("return {");
 
 				writer.WriteLine($"\ttexture = love.graphics.newImage('{arguments.AtlasOutputFile}'),");

--- a/Nez.SpriteAtlasPacker/SpriteAtlasPacker/Exporters/TxtMapExporter.cs
+++ b/Nez.SpriteAtlasPacker/SpriteAtlasPacker/Exporters/TxtMapExporter.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 
 namespace Nez.Tools.Atlases
 {
@@ -16,8 +17,22 @@ namespace Nez.Tools.Atlases
 			List<string> outputFiles = new List<string>(keys);
 			outputFiles.Sort();
 
+			// compute the names of images to write
+			IDictionary<string, string> imagesNames;
+			if (arguments.WritePaths)
+			{
+				string commonPath = MiscHelper.GetCommonPath(outputFiles);
+				imagesNames = outputFiles.ToDictionary(k => k, v => v.Substring(commonPath.Length));
+			}
+			else
+			{
+				imagesNames = outputFiles.ToDictionary(k => k, v => Path.GetFileNameWithoutExtension(v));
+			}
+
 			using (StreamWriter writer = new StreamWriter(filename))
 			{
+				writer.NewLine = arguments.LF ? "\n" : "\r\n";
+
 				foreach (var image in outputFiles)
 				{
 					// get the destination rectangle
@@ -26,7 +41,7 @@ namespace Nez.Tools.Atlases
 					// write out the destination rectangle for this bitmap
 					writer.WriteLine(string.Format(
 	                 	"{0} = {1} {2} {3} {4}", 
-	                 	Path.GetFileNameWithoutExtension(image), 
+	                 	imagesNames[image], 
 	                 	destination.X, 
 	                 	destination.Y, 
 	                 	destination.Width, 

--- a/Nez.SpriteAtlasPacker/SpriteAtlasPacker/Packing/MiscHelper.cs
+++ b/Nez.SpriteAtlasPacker/SpriteAtlasPacker/Packing/MiscHelper.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace Nez.Tools.Atlases
 {
@@ -30,6 +33,33 @@ namespace Nez.Tools.Atlases
 			for (int i = 1; i < sizeof(int) * 8; i <<= 1)
 				k = k | k >> i;
 			return k + 1;
+		}
+
+		// common prefix path for all the given files, e.g. for
+		// C:\dir1\file1.png
+		// C:\dir1\file2.jpg
+		// will return "C:\dir1\"
+		public static string GetCommonPath(IEnumerable<string> files)
+		{
+			if (files == null || !files.Any())
+				throw new ArgumentNullException(nameof(files),
+					"No file is given. Provide at least one.");
+
+			var orderedFiles = files.OrderBy(file => file.Length);
+			var shortestFile = orderedFiles.First();
+			int lastCommonDirectoryNameStart = 0;
+			for (int i = 0; i < shortestFile.Length; i++)
+			{
+				char currentChar = shortestFile[i];
+				bool isThisCharInOtherFiles = files.All(file => file[i] == currentChar);
+				if (!isThisCharInOtherFiles)
+					break;
+
+				bool isPathSeparator = currentChar == '\\';
+				if (isPathSeparator)
+					lastCommonDirectoryNameStart = i;
+			}
+			return shortestFile.Substring(0, lastCommonDirectoryNameStart + 1);
 		}
 	}
 }


### PR DESCRIPTION
Generated .atlas file had inconsistent line endings (\n and \r\n all over the map file).
Now CRLF (\r\n) is the default line terminator, however added the option to change it (parameter -lf).
Also there are 2 more new options:
-writePaths - the map will write images relative paths (useful when you have the hierarchy of images kinda "enemy/idle.png" and "player/idle.png". Without this feature you'll get an error because both images have the same name);
-noOrigins - with this flag images' origins won't be written in the map file (this feature is for custom loaders and saving space as all the origins are basically the same numbers).
All new parameters are optional.