### PR TITLE
Removed unnecessary steps in getting command attributes

### DIFF
--- a/Nez.Portable/Debug/Console/DebugConsole.cs
+++ b/Nez.Portable/Debug/Console/DebugConsole.cs
@@ -665,10 +665,7 @@ namespace Nez.Console
 				foreach (var method in type.DeclaredMethods)
 				{
 					CommandAttribute attr = null;
-					var attrs = method.GetCustomAttributes(typeof(CommandAttribute), false)
-						.Where(a => a is CommandAttribute);
-					if (IEnumerableExt.Count(attrs) > 0)
-						attr = attrs.First() as CommandAttribute;
+					attr = method.GetCustomAttribute<CommandAttribute>(false);
 
 					if (attr != null)
 						ProcessMethod(method, attr);


### PR DESCRIPTION
No need to get a list of attributes with type CommandAttribute as any method will only have 1 command attribute per method. Also using generic version of method is more readable.