### PR TITLE
Add MaxDeltaTime to Time class

### DIFF
--- a/Nez.Portable/Utils/Time.cs
+++ b/Nez.Portable/Utils/Time.cs
@@ -48,9 +48,16 @@ namespace Nez
 		/// </summary>
 		public static uint FrameCount;
 
+		/// <summary>
+		/// Maximum value that DeltaTime can be. This can be useful to prevent physics from breaking when dragging
+		/// the game window or if your game hitches.
+		/// </summary>
+		public static float MaxDeltaTime = float.MaxValue;
 
 		internal static void Update(float dt)
 		{
+			if(dt > MaxDeltaTime)
+				dt = MaxDeltaTime;
 			TotalTime += dt;
 			DeltaTime = dt * TimeScale;
 			AltDeltaTime = dt * AltTimeScale;


### PR DESCRIPTION
When dragging the game window on Windows 10, the game will stop updating. When the game resumes, `Time.DeltaTime` is a huge value, which can bork out the game physics. Setting a `MaxDeltaTime` to something like `1f / 60` or `1f / 30` allows us to keep this value under control.