### PR TITLE
Added setTexture function to SpriteRenderer

### DIFF
--- a/Nez.Portable/ECS/Components/Renderables/Sprites/SpriteRenderer.cs
+++ b/Nez.Portable/ECS/Components/Renderables/Sprites/SpriteRenderer.cs
@@ -115,6 +115,15 @@ namespace Nez.Sprites
 		}
 
 		/// <summary>
+		/// sets the Texture by creating a new sprite. See SetSprite() for details.
+		/// </summary>
+		public SpriteRenderer SetTexture(Texture2D texture)
+		{
+			SetSprite(new Sprite(texture));
+			return this;
+		}
+
+		/// <summary>
 		/// sets the origin for the Renderable
 		/// </summary>
 		public SpriteRenderer SetOrigin(Vector2 origin)


### PR DESCRIPTION
Improves code quality via showing intentions better.

example:
```
var spriteRenderer = Entity.GetComponent<SpriteRenderer>();
spriteRenderer.SetSprite(new Sprite(newTexture));
// vs
spriteRenderer.SetTexture(newTexture);
```