### PR TITLE
Added check to see if circle overlaps box

### DIFF
--- a/Nez.Portable/Physics/SpatialHash.cs
+++ b/Nez.Portable/Physics/SpatialHash.cs
@@ -420,8 +420,11 @@ namespace Nez.Spatial
 			{
 				if (collider is BoxCollider)
 				{
-					results[resultCounter] = collider;
-					resultCounter++;
+					if (collider.Shape.Overlaps(_overlapTestCirce))
+					{
+						results[resultCounter] = collider;
+						resultCounter++;
+					}
 				}
 				else if (collider is CircleCollider)
 				{


### PR DESCRIPTION
When calling OverlapCircle, it wasn't checking to see if the circle overlapped the box, instead it was checking to see if the circle's bounds were overlapping it. Now it does the same check as it does for the other shapes.