### PR TITLE
Function for Random Unit Vectors

### DIFF
--- a/Nez.Portable/Math/Random.cs
+++ b/Nez.Portable/Math/Random.cs
@@ -74,6 +74,17 @@ namespace Nez
 
 
 		/// <summary>
+		/// Returns a random unit vector with direction between 0 and 2 * PI
+		/// </summary>
+		/// <returns></returns>
+		public static Vector2 NextUnitVector()
+		{
+			float angle = NextAngle();
+			return new Vector2(Mathf.Cos(angle), Mathf.Sin(angle));
+		}
+
+
+		/// <summary>
 		/// returns a random color
 		/// </summary>
 		/// <returns>The color.</returns>


### PR DESCRIPTION
A useful function for game programming when direction is involved.

For example:
```
float wobble = 2f;
Vector2 point = new Vector2(10.1f, -14.3f);
Vector2 pointTransformed = point + Nez.Random.NextUnitVector() * wobble;
``` 