### PR TITLE
Move Label fontScale fields into LabelStyle

### DIFF
--- a/Nez.Portable/UI/Widgets/ImageTextButton.cs
+++ b/Nez.Portable/UI/Widgets/ImageTextButton.cs
@@ -20,7 +20,7 @@ namespace Nez.UI
 			image = new Image();
 			image.SetScaling(Scaling.Fit);
 
-			label = new Label(text, style.Font, style.FontColor);
+			label = new Label(text, style.Font, style.FontColor, style.FontScaleX, style.FontScaleY);
 			label.SetAlignment(UI.Align.Center);
 
 			Add(image);
@@ -52,6 +52,8 @@ namespace Nez.UI
 				var labelStyle = label.GetStyle();
 				labelStyle.Font = style.Font;
 				labelStyle.FontColor = style.FontColor;
+				labelStyle.FontScaleX = style.FontScaleX;
+				labelStyle.FontScaleY = style.FontScaleY;
 				label.SetStyle(labelStyle);
 			}
 		}
@@ -178,6 +180,8 @@ namespace Nez.UI
 				CheckedFontColor = CheckedFontColor,
 				CheckedOverFontColor = CheckedOverFontColor,
 				DisabledFontColor = DisabledFontColor,
+				FontScaleX = FontScaleX,
+				FontScaleY = FontScaleY,
 
 				ImageUp = ImageUp,
 				ImageDown = ImageDown,

--- a/Nez.Portable/UI/Widgets/Label.cs
+++ b/Nez.Portable/UI/Widgets/Label.cs
@@ -42,8 +42,6 @@ namespace Nez.UI
 		// configuration
 		LabelStyle _style;
 		string _text;
-		float _fontScaleX = 1;
-		float _fontScaleY = 1;
 
 		int labelAlign = AlignInternal.Left;
 
@@ -73,6 +71,15 @@ namespace Nez.UI
 
 		public Label(string text, BitmapFont font, Color fontColor) : this(text, new LabelStyle(font, fontColor))
 		{ }
+
+
+		public Label(string text, BitmapFont font, Color fontColor, float fontScale) : this(text, font, fontColor, fontScale, fontScale)
+        { }
+
+
+        public Label(string text, BitmapFont font, Color fontColor, float fontScaleX, float fontScaleY) : this(text, new LabelStyle(font, fontColor, fontScaleX, fontScaleY))
+        { }
+
 
 
 		public Label(string text, BitmapFont font) : this(text, font, Color.White)
@@ -118,7 +125,7 @@ namespace Nez.UI
 				if (_style.Background != null)
 					widthCalc -= _style.Background.LeftWidth + _style.Background.RightWidth;
 
-				_wrappedString = _style.Font.WrapText(_text, widthCalc / _fontScaleX);
+				_wrappedString = _style.Font.WrapText(_text, widthCalc / _style.FontScaleX);
 			}
 			else if (_ellipsis != null && width > 0)
 			{
@@ -127,14 +134,14 @@ namespace Nez.UI
 				if (_style.Background != null)
 					widthCalc -= _style.Background.LeftWidth + _style.Background.RightWidth;
 
-				_wrappedString = _style.Font.TruncateText(_text, _ellipsis, widthCalc / _fontScaleX);
+				_wrappedString = _style.Font.TruncateText(_text, _ellipsis, widthCalc / _style.FontScaleX);
 			}
 			else
 			{
 				_wrappedString = _text;
 			}
 
-			_prefSize = _style.Font.MeasureString(_wrappedString) * new Vector2(_fontScaleX, _fontScaleY);
+			_prefSize = _style.Font.MeasureString(_wrappedString) * new Vector2(_style.FontScaleX, _style.FontScaleY);
 		}
 
 
@@ -216,8 +223,8 @@ namespace Nez.UI
 
 		public Label SetFontScale(float fontScale)
 		{
-			_fontScaleX = fontScale;
-			_fontScaleY = fontScale;
+			_style.FontScaleX = fontScale;
+			_style.FontScaleY = fontScale;
 			InvalidateHierarchy();
 			return this;
 		}
@@ -225,8 +232,8 @@ namespace Nez.UI
 
 		public Label SetFontScale(float fontScaleX, float fontScaleY)
 		{
-			_fontScaleX = fontScaleX;
-			_fontScaleY = fontScaleY;
+			_style.FontScaleX = fontScaleX;
+			_style.FontScaleY = fontScaleY;
 			InvalidateHierarchy();
 			return this;
 		}
@@ -321,7 +328,7 @@ namespace Nez.UI
 			else
 			{
 				textWidth = width;
-				textHeight = _style.Font.LineHeight * _fontScaleY;
+				textHeight = _style.Font.LineHeight * _style.FontScaleY;
 			}
 
 			if ((labelAlign & AlignInternal.Bottom) != 0)
@@ -359,7 +366,7 @@ namespace Nez.UI
 			_style.Background?.Draw(batcher, x, y, width == 0 ? _prefSize.X : width, height, color);
 
 			batcher.DrawString(_style.Font, _wrappedString, new Vector2(x, y) + _textPosition,
-				_style.FontColor, 0, Vector2.Zero, new Vector2(_fontScaleX, _fontScaleY), SpriteEffects.None, 0);
+				_style.FontColor, 0, Vector2.Zero, new Vector2(_style.FontScaleX, _style.FontScaleY), SpriteEffects.None, 0);
 		}
 	}
 
@@ -372,6 +379,9 @@ namespace Nez.UI
 		public Color FontColor = Color.White;
 		public BitmapFont Font;
 		public IDrawable Background;
+		public float FontScaleX = 1f;
+		public float FontScaleY = 1f;
+		public float FontScale { set { FontScaleX = value; FontScaleY = value; } }
 
 
 		public LabelStyle()
@@ -380,11 +390,23 @@ namespace Nez.UI
 		}
 
 
-		public LabelStyle(BitmapFont font, Color fontColor)
+		public LabelStyle(BitmapFont font, Color fontColor) : this(font, fontColor, 1f)
+        { }
+
+
+        public LabelStyle(BitmapFont font, Color fontColor, float fontScaleX, float fontScaleY)
 		{
 			Font = font ?? Graphics.Instance.BitmapFont;
 			FontColor = fontColor;
+			FontScaleX = fontScaleX;
+			FontScaleY = fontScaleY;
 		}
+
+
+		public LabelStyle(BitmapFont font, Color fontColor, float fontScale) : this(font, fontColor, fontScale, fontScale)
+        {
+
+        }
 
 
 		public LabelStyle(Color fontColor) : this(null, fontColor)
@@ -397,7 +419,9 @@ namespace Nez.UI
 			{
 				FontColor = FontColor,
 				Font = Font,
-				Background = Background
+				Background = Background,
+				FontScaleX = FontScaleX,
+				FontScaleY = FontScaleY
 			};
 		}
 	}

--- a/Nez.Portable/UI/Widgets/TextButton.cs
+++ b/Nez.Portable/UI/Widgets/TextButton.cs
@@ -14,7 +14,7 @@ namespace Nez.UI
 		public TextButton(string text, TextButtonStyle style) : base(style)
 		{
 			SetStyle(style);
-			label = new Label(text, style.Font, style.FontColor);
+			label = new Label(text, style.Font, style.FontColor, style.FontScaleX, style.FontScaleY);
 			label.SetAlignment(UI.Align.Center);
 
 			Add(label).Expand().Fill();
@@ -41,6 +41,8 @@ namespace Nez.UI
 				var labelStyle = label.GetStyle();
 				labelStyle.Font = textButtonStyle.Font;
 				labelStyle.FontColor = textButtonStyle.FontColor;
+				labelStyle.FontScaleX = textButtonStyle.FontScaleX;
+				labelStyle.FontScaleY = textButtonStyle.FontScaleY;
 				label.SetStyle(labelStyle);
 			}
 		}
@@ -119,6 +121,8 @@ namespace Nez.UI
 		/** Optional. */
 		public Color FontColor = Color.White;
 		public Color? DownFontColor, OverFontColor, CheckedFontColor, CheckedOverFontColor, DisabledFontColor;
+		public float FontScaleX, FontScaleY = 1;
+		public float FontScale { set { FontScaleX = value; FontScaleY = value; } }
 
 
 		public TextButtonStyle()
@@ -167,7 +171,9 @@ namespace Nez.UI
 				OverFontColor = OverFontColor,
 				CheckedFontColor = CheckedFontColor,
 				CheckedOverFontColor = CheckedOverFontColor,
-				DisabledFontColor = DisabledFontColor
+				DisabledFontColor = DisabledFontColor,
+				FontScaleX = FontScaleX,
+				FontScaleY = FontScaleY,
 			};
 		}
 	}

--- a/Nez.Portable/UI/Widgets/Window.cs
+++ b/Nez.Portable/UI/Widgets/Window.cs
@@ -31,7 +31,7 @@ namespace Nez.UI
 			touchable = Touchable.Enabled;
 			Clip = true;
 
-			titleLabel = new Label(title, new LabelStyle(style.TitleFont, style.TitleFontColor));
+			titleLabel = new Label(title, new LabelStyle(style.TitleFont, style.TitleFontColor, style.TitleFontScaleX, style.TitleFontScaleY));
 			titleLabel.SetEllipsis(true);
 
 			titleTable = new Table();
@@ -216,6 +216,8 @@ namespace Nez.UI
 			var labelStyle = titleLabel.GetStyle();
 			labelStyle.Font = style.TitleFont ?? labelStyle.Font;
 			labelStyle.FontColor = style.TitleFontColor;
+			labelStyle.FontScaleX = style.TitleFontScaleX;
+			labelStyle.FontScaleY = style.TitleFontScaleY;
 			titleLabel.SetStyle(labelStyle);
 
 			InvalidateHierarchy();
@@ -363,6 +365,12 @@ namespace Nez.UI
 		public BitmapFont TitleFont;
 
 		/** Optional. */
+		public float TitleFontScaleX = 1f;
+
+		/** Optional. */
+		public float TitleFontScaleY = 1f;
+
+		/** Optional. */
 		public IDrawable Background;
 
 		/** Optional. */
@@ -372,18 +380,30 @@ namespace Nez.UI
 		public IDrawable StageBackground;
 
 
+
+
 		public WindowStyle()
 		{
 			TitleFont = Graphics.Instance.BitmapFont;
 		}
 
 
-		public WindowStyle(BitmapFont titleFont, Color titleFontColor, IDrawable background)
-		{
-			TitleFont = titleFont ?? Graphics.Instance.BitmapFont;
-			Background = background;
-			TitleFontColor = titleFontColor;
-		}
+        public WindowStyle(BitmapFont titleFont, Color titleFontColor, IDrawable background) : this(titleFont, titleFontColor, background, 1f)
+        { }
+
+
+        public WindowStyle(BitmapFont titleFont, Color titleFontColor, IDrawable background, float titleFontScale) : this(titleFont, titleFontColor, background, titleFontScale, titleFontScale)
+        { }
+
+
+        public WindowStyle(BitmapFont titleFont, Color titleFontColor, IDrawable background, float titleFontScaleX, float titleFontScaleY)
+        {
+            TitleFont = titleFont ?? Graphics.Instance.BitmapFont;
+            Background = background;
+            TitleFontColor = titleFontColor;
+            TitleFontScaleX = titleFontScaleX;
+            TitleFontScaleY = titleFontScaleY;
+        }
 
 
 		public WindowStyle Clone()
@@ -393,6 +413,8 @@ namespace Nez.UI
 				Background = Background,
 				TitleFont = TitleFont,
 				TitleFontColor = TitleFontColor,
+				TitleFontScaleX = TitleFontScaleX,
+				TitleFontScaleY = TitleFontScaleY,
 				StageBackground = StageBackground
 			};
 		}


### PR DESCRIPTION
Shifts the existing `_fontScaleX` and `_fontScaleY` fields from properties of a `Label` to properties within `LabelStyle`. This allows font sizes for labels, TextButtons, etc. to be set globally through the skin/style system.. Also exposes these new style fields on the style objects for UI elements that contain `Label`s as children (e.g. `TextButton`/`TextButtonStyle` and `Window`/`WindowStyle`).

This should partially resolve [Issue 600](https://github.com/prime31/Nez/issues/600) - it provides a style-level means of scaling text on `Label` and UI elements containing `Label`, but doesn't change anything about the `TextField` element. Could potentially do something similar with `TextField`, but there's no current scaling logic in that class so I left it alone for now.

Thanks for creating this framework by the way! Have found it to be very helpful 😃 