### PR TITLE
Fix errors when serializing an Array with JsonEncoder

### DIFF
--- a/Nez.Persistence/Json/JsonEncoder.cs
+++ b/Nez.Persistence/Json/JsonEncoder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
@@ -255,12 +255,19 @@ namespace Nez.Persistence
 			if (!forceTypeHint && _settings.TypeNameHandling == TypeNameHandling.Auto)
 			{
 				var listType = value.GetType();
-				foreach (Type interfaceType in listType.GetInterfaces())
+				if(listType.IsArray)
 				{
-					if (interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition() == typeof(IList<>))
+					listItemType = listType.GetElementType();
+				}
+				else
+				{
+					foreach (Type interfaceType in listType.GetInterfaces())
 					{
-						listItemType = listType.GetGenericArguments()[0];
-						break;
+						if (interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition() == typeof(IList<>))
+						{
+							listItemType = listType.GetGenericArguments()[0];
+							break;
+						}
 					}
 				}
 			}
@@ -270,7 +277,7 @@ namespace Nez.Persistence
 			foreach (var obj in value)
 			{
 				WriteValueDelimiter();
-				forceTypeHint = forceTypeHint || (listItemType != null && listItemType != obj.GetType());
+				forceTypeHint = forceTypeHint || (listItemType != null && listItemType != obj?.GetType());
 				EncodeValue(obj, forceTypeHint);
 			}
 


### PR DESCRIPTION
Serializing an array such as
```csharp
class Example
{
    public string[] MyArray = new string[5];
}
```
will throw an error in JsonEncoder on this line: https://github.com/prime31/Nez/blob/ce2405d0b6b9f94da5e34a6af22c03e27affc59f/Nez.Persistence/Json/JsonEncoder.cs#L262

For Arrays, `listType.GetElementType()` is needed instead to fetch the Array's element type. I've added a simple check to fix this.

Additionally, the encoder will crash on this line when attempting to save null elements in a list or array:
https://github.com/prime31/Nez/blob/ce2405d0b6b9f94da5e34a6af22c03e27affc59f/Nez.Persistence/Json/JsonEncoder.cs#L273

`obj` is null in this case, so I've added a simple null check to fix it.