### PR TITLE
Add ability to simulate VirtualInput activation

### DIFF
--- a/Nez.Portable/Input/Virtual/VirtualAxis.cs
+++ b/Nez.Portable/Input/Virtual/VirtualAxis.cs
@@ -10,6 +10,9 @@ namespace Nez
 	public class VirtualAxis : VirtualInput
 	{
 		public List<Node> Nodes = new List<Node>();
+		
+		float _simulatedValue;
+		int _simulationStep;
 
 		public float Value
 		{
@@ -22,7 +25,7 @@ namespace Nez
 						return val;
 				}
 
-				return 0;
+				return _simulatedValue;
 			}
 		}
 
@@ -38,10 +41,28 @@ namespace Nez
 		}
 
 
+		public void Simulate(float value)
+		{
+			_simulatedValue = value;
+			_simulationStep = 1;
+		}
+		
+
 		public override void Update()
 		{
 			for (var i = 0; i < Nodes.Count; i++)
 				Nodes[i].Update();
+
+			switch (_simulationStep)
+			{
+				case 1:
+					_simulationStep++;
+					break;
+				case 2:
+					_simulatedValue = 0;
+					_simulationStep = 0;
+					break;
+			}
 		}
 
 

--- a/Nez.Portable/Input/Virtual/VirtualButton.cs
+++ b/Nez.Portable/Input/Virtual/VirtualButton.cs
@@ -21,6 +21,11 @@ namespace Nez
 		float _repeatCounter;
 		bool _willRepeat;
 
+		bool _simulatePress;
+		bool _simulateDown;
+		bool _simulateRelease;
+		int _simulationStep;
+
 
 		public VirtualButton(float bufferTime)
 		{
@@ -59,6 +64,12 @@ namespace Nez
 			_willRepeat = firstRepeatTime > 0;
 			if (!_willRepeat)
 				IsRepeating = false;
+		}
+
+
+		public void Simulate()
+		{
+			_simulationStep = 1;
 		}
 
 
@@ -103,6 +114,29 @@ namespace Nez
 					}
 				}
 			}
+
+			switch (_simulationStep)
+			{
+				case 1:
+					_simulatePress = true;
+					_simulateDown = true;
+					_simulationStep++;
+					break;
+				case 2:
+					_simulatePress = false;
+					_simulationStep++;
+					break;
+				case 3:
+					_simulateDown = false;
+					_simulateRelease = true;
+					_simulationStep++;
+					break;
+				case 4:
+					_simulateRelease = false;
+					_simulationStep = -1;
+					break;
+			}
+
 		}
 
 
@@ -114,7 +148,7 @@ namespace Nez
 					if (node.IsDown)
 						return true;
 
-				return false;
+				return _simulateDown;
 			}
 		}
 
@@ -130,7 +164,7 @@ namespace Nez
 					if (node.IsPressed)
 						return true;
 
-				return false;
+				return _simulatePress;
 			}
 		}
 
@@ -143,7 +177,7 @@ namespace Nez
 					if (node.IsReleased)
 						return true;
 
-				return false;
+				return _simulateRelease;
 			}
 		}
 

--- a/Nez.Portable/Input/Virtual/VirtualIntegerAxis.cs
+++ b/Nez.Portable/Input/Virtual/VirtualIntegerAxis.cs
@@ -12,6 +12,9 @@ namespace Nez
 	public class VirtualIntegerAxis : VirtualInput
 	{
 		public List<VirtualAxis.Node> Nodes = new List<VirtualAxis.Node>();
+		
+		int _simulatedValue;
+		int _simulationStep;
 
 		public int Value
 		{
@@ -24,7 +27,7 @@ namespace Nez
 						return Math.Sign(val);
 				}
 
-				return 0;
+				return _simulatedValue;
 			}
 		}
 
@@ -40,10 +43,28 @@ namespace Nez
 		}
 
 
+		public void Simulate(int value)
+		{
+			_simulatedValue = value;
+			_simulationStep = 1;
+		}
+
+
 		public override void Update()
 		{
 			for (var i = 0; i < Nodes.Count; i++)
 				Nodes[i].Update();
+			
+			switch (_simulationStep)
+			{
+				case 1:
+					_simulationStep++;
+					break;
+				case 2:
+					_simulatedValue = 0;
+					_simulationStep = 0;
+					break;
+			}
 		}
 
 

--- a/Nez.Portable/Input/Virtual/VirtualJoystick.cs
+++ b/Nez.Portable/Input/Virtual/VirtualJoystick.cs
@@ -13,6 +13,9 @@ namespace Nez
 		public List<Node> Nodes = new List<Node>();
 		public bool Normalized;
 
+		Vector2 _simulatedValue = Vector2.Zero;
+		int _simulationStep;
+
 		public Vector2 Value
 		{
 			get
@@ -28,7 +31,7 @@ namespace Nez
 					}
 				}
 
-				return Vector2.Zero;
+				return _simulatedValue;
 			}
 		}
 
@@ -46,10 +49,29 @@ namespace Nez
 		}
 
 
+		public void Simulate(Vector2 value)
+		{
+			_simulatedValue = value;
+			_simulationStep = 1;
+		}
+		
+
 		public override void Update()
 		{
 			for (int i = 0; i < Nodes.Count; i++)
 				Nodes[i].Update();
+			
+			
+			switch (_simulationStep)
+			{
+				case 1:
+					_simulationStep++;
+					break;
+				case 2:
+					_simulatedValue = Vector2.Zero;
+					_simulationStep = 0;
+					break;
+			}
 		}
 
 


### PR DESCRIPTION
This changes the four VirtualInput classes to include a `Simulate(...)` method that allows (you guessed it) simulating an input.

The implementation uses the `Update()` method to keep the input activated for one frame, with the help of a `simulationStep` counter.

This may be pretty hacky, so I'm open to reimplementing it in a cleaner way if the maintainers so desire.