### PR TITLE
#689 initialize TextButton FontScaleX to 1 instead of 0

### DIFF
--- a/Nez.Portable/UI/Widgets/TextButton.cs
+++ b/Nez.Portable/UI/Widgets/TextButton.cs
@@ -121,7 +121,8 @@ namespace Nez.UI
 		/** Optional. */
 		public Color FontColor = Color.White;
 		public Color? DownFontColor, OverFontColor, CheckedFontColor, CheckedOverFontColor, DisabledFontColor;
-		public float FontScaleX, FontScaleY = 1;
+		public float FontScaleX = 1;
+		public float FontScaleY = 1;
 		public float FontScale { set { FontScaleX = value; FontScaleY = value; } }
 
 


### PR DESCRIPTION
As pointed out by ilmenit and the issue title, the FonstScaleX was initialized to 0.
![image](https://user-images.githubusercontent.com/69400800/137643680-3f7ea548-ca60-4df0-b489-d295e754887e.png)
