### PR TITLE
FNA pixel offset

### DIFF
--- a/FAQs/FNACompat.md
+++ b/FAQs/FNACompat.md
@@ -1,5 +1,5 @@
 FNA Compatibility
 ==========
-To make getting up and running with FNA easier there are separate csproj files (*.FNA.csproj). Note that you still have to install the required FNA native libs per the [FNA documentation](https://github.com/FNA-XNA/FNA/wiki/1:-Download-and-Update-FNA). The [MonoGameCompat class](https://github.com/prime31/Nez/blob/62bbcca5e346413cacc2c3f9e765e11ead568de5/Nez-PCL/Utils/MonoGameCompat.cs) is included as well and consists of a few extension methods that implmement some commonly used method that are in MonoGame but not in FNA.
+To make getting up and running with FNA easier there are separate csproj files (*.FNA.csproj). Note that you still have to install the required FNA native libs per the [FNA documentation](https://github.com/FNA-XNA/FNA/wiki/1:-Download-and-Update-FNA). The [MonoGameCompat class](../Nez.Portable/Utils/MonoGameCompat.cs) is included as well and consists of a few extension methods that implmement some commonly used method that are in MonoGame but not in FNA.
 
-See the "Using Nez with FNA" section of the [README.md](README.md#using-nez-with-fna) for setup details.
+See the "Using Nez with FNA" section of the [README.md](../README.md#using-nez-with-fna) for setup details.

--- a/Nez.Portable/Graphics/Batcher/Batcher.cs
+++ b/Nez.Portable/Graphics/Batcher/Batcher.cs
@@ -71,7 +71,12 @@ namespace Nez
 		#region static variables and constants
 
 		/// <summary>if true, the older FNA half-pixel offset will be used when creating the ortho matrix</summary>
-		public static bool UseFnaHalfPixelMatrix = false;
+		public static bool UseFnaHalfPixelMatrix =
+#if FNA
+			true;
+#else
+			false;
+#endif
 
 		const int MAX_SPRITES = 2048;
 		const int MAX_VERTICES = MAX_SPRITES * 4;


### PR DESCRIPTION
After I got the FNA.Samples running, it rendered a bit messed up:

![image](https://user-images.githubusercontent.com/69400800/139142118-84bf5df7-3318-4a9f-b788-da097538b673.png)

Similar existing Issues (#618 , #571) seem to be rooted to .NET Core or maybe .NET 5

But -> I am pretty sure I am NOT using .NET Core.
The Application also seems to be pretty sure its running under Mono. Proofs:

![image](https://user-images.githubusercontent.com/69400800/139142689-73ffd76e-c1ad-446d-9f86-85b9164fb674.png)

![image](https://user-images.githubusercontent.com/69400800/139142700-1aed4f38-998f-4423-9d03-f93eb89b3dc0.png)

Setting `Batcher.UseFnaHalfPixelMatrix = true` fixes the rendering.

It seems like in the NEZ 0.10.0 release, half-pixel offset was always used for FNA.
That changed here: https://github.com/prime31/Nez/commit/a5f14075cf8c8424539231a05b098cd0e6428249
Now the half-pixel offset is disabled by default for FNA.

![image](https://user-images.githubusercontent.com/69400800/139143567-14bc80e4-2474-4cd2-ba71-ead11914435e.png)

I tested this with:
* The current Master-Branch for FNA
* The current Master-Branch for NEZ
* Windows+Linux

And I need `Batcher.UseFnaHalfPixelMatrix = true` for FNA Projects to render properly.
So I propose to default this flag to true for FNA Projects.

![image](https://user-images.githubusercontent.com/69400800/139145445-790b1b40-e3c7-419e-b967-02b461588884.png)
