### PR TITLE
ContentPathGenerator.tt can now be run from the root-folder instead of a sub-folder

### DIFF
--- a/T4Templates/ContentPathGenerator.tt
+++ b/T4Templates/ContentPathGenerator.tt
@@ -92,7 +92,7 @@ namespace Nez
 				continue;
 			
 			// clear out all of the path up to the sourceFolder so we get just the relative path to the Content folder
-			var finalPath = file.Substring( file.IndexOf( sourceFolder ) + 3 );
+			var finalPath = file.Substring( file.IndexOf( sourceFolder ) );
 			var fileInfo = new FileInfo( file );
 			var className = GenerateClassName( fileInfo.Name.Replace(Path.GetExtension(fileInfo.Name), "") );
 


### PR DESCRIPTION
As noted by @magruder85 in #704:
The ContentPathGenerator.tt trimmed 3 chars from the resulting Paths if run from the Root folder.