### PR TITLE
Removes CS0162 'Unreachable code detected' warning

### DIFF
--- a/Nez.Portable/Assets/Tiled/Runtime/TiledRendering.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledRendering.cs
@@ -145,10 +145,8 @@ namespace Nez.Tiled
 					break;
 				case OrientationType.Staggered:
 					throw new NotImplementedException("Staggered Tiled maps are not yet supported.");
-					break;
 				case OrientationType.Hexagonal:
 					throw new NotImplementedException("Hexagonal Tiled maps are not yet supported.");
-					break;
 				case OrientationType.Unknown:
 				case OrientationType.Orthogonal:
 				default:
@@ -200,10 +198,8 @@ namespace Nez.Tiled
 					break;
 				case OrientationType.Staggered:
 					throw new NotImplementedException("Staggered Tiled maps are not yet supported.");
-					break;
 				case OrientationType.Hexagonal:
 					throw new NotImplementedException("Hexagonal Tiled maps are not yet supported.");
-					break;
 				case OrientationType.Unknown:
 				case OrientationType.Orthogonal:
 				default:


### PR DESCRIPTION
Removes 4x CS0162 'Unreachable code detected' warnings from the `Nez.Portable` project.