### PR TITLE
Extending SpriteAtlasPacker by ability to preserve Origins

### DIFF
--- a/Nez.SpriteAtlasPacker/README.md
+++ b/Nez.SpriteAtlasPacker/README.md
@@ -20,18 +20,19 @@ Sprite Atlas Packer also handles animations. Any subdirectories that contain ima
 ## Options
 
 ```
-<input>           Images to pack. Default:''
-/image:string     Output file name for the image.
-/map:string       Output file name for the map.
-/mw:int           Maximum ouput width. Default:'4096'
-/mh:int           Maximum ouput height. Default:'4096'
-/pad:int          Padding between images. Default:'1'
-/pow2             Ensures output dimensions are powers of two.
-/sqr              Ensures output is square.
-/originX:float    Origin X for the images Default:'0.5'
-/originY:float    Origin Y for the images Default:'0.5'
-/fps:int          Framerate for any animations Default:'8'
-/lua              Output LOVE2D lua file
+<input>            Images to pack. Default:''
+/image:string      Output file name for the image.
+/map:string        Output file name for the map.
+/originsMap:string Input map file name with Origins to use (you can use existing Output map file to keep origins)
+/mw:int            Maximum ouput width. Default:'4096'
+/mh:int            Maximum ouput height. Default:'4096'
+/pad:int           Padding between images. Default:'1'
+/pow2              Ensures output dimensions are powers of two.
+/sqr               Ensures output is square.
+/originX:float     Origin X for the images Default:'0.5'
+/originY:float     Origin Y for the images Default:'0.5'
+/fps:int           Framerate for any animations Default:'8'
+/lua               Output LOVE2D lua file
 ```
 
 

--- a/Nez.SpriteAtlasPacker/SpriteAtlasPacker.Console/ProgramArguments.cs
+++ b/Nez.SpriteAtlasPacker/SpriteAtlasPacker.Console/ProgramArguments.cs
@@ -31,6 +31,9 @@ namespace Nez.Tools.Atlases.Console
 		[Argument(ArgumentType.AtMostOnce, ShortName = "", HelpText = "Ensures output is square.")]
 		public bool sqr;
 
+		[Argument(ArgumentType.AtMostOnce, ShortName = "", HelpText = "Input map file name with Origins to use (you can use existing Output map file to keep origins)")]
+		public string originsMap;
+
 		[Argument(ArgumentType.AtMostOnce, ShortName = "", HelpText = "Origin X for the images", DefaultValue = Constants.DefaultOrigin)]
 		public float originX = Constants.DefaultOrigin;
 
@@ -74,6 +77,7 @@ namespace Nez.Tools.Atlases.Console
 			{
 				AtlasOutputFile = image,
 				MapOutputFile = map,
+				MapInputFile = originsMap,
 				AtlasMaxWidth = mw,
 				AtlasMaxHeight = mh,
 				Padding = pad,

--- a/Nez.SpriteAtlasPacker/SpriteAtlasPacker.Console/Properties/launchSettings.json
+++ b/Nez.SpriteAtlasPacker/SpriteAtlasPacker.Console/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "SpriteAtlasPacker.Console": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/Nez.SpriteAtlasPacker/SpriteAtlasPacker.Console/SpriteAtlasPacker.Console.csproj
+++ b/Nez.SpriteAtlasPacker/SpriteAtlasPacker.Console/SpriteAtlasPacker.Console.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   	<PropertyGroup>
     	<OutputType>Exe</OutputType>
     	<TargetFramework>net471</TargetFramework>

--- a/Nez.SpriteAtlasPacker/SpriteAtlasPacker.Console/SpriteAtlasPacker.Console.csproj
+++ b/Nez.SpriteAtlasPacker/SpriteAtlasPacker.Console/SpriteAtlasPacker.Console.csproj
@@ -9,7 +9,7 @@
   	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   	<ItemGroup>
-  		<Compile Include="..\SpriteAtlasPacker\*.cs;..\SpriteAtlasPacker\Packing\*.cs;..\SpriteAtlasPacker\Exporters\*.cs;" Link="SpriteAtlasPacker\%(Filename)%(Extension)" />
+  		<Compile Include="..\SpriteAtlasPacker\*.cs;..\SpriteAtlasPacker\Packing\*.cs;..\SpriteAtlasPacker\Exporters\*.cs;..\SpriteAtlasPacker\Importers\*.cs;" Link="SpriteAtlasPacker\%(Filename)%(Extension)" />
 	</ItemGroup>
 	
 </Project>

--- a/Nez.SpriteAtlasPacker/SpriteAtlasPacker.sln
+++ b/Nez.SpriteAtlasPacker/SpriteAtlasPacker.sln
@@ -1,13 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2026
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31624.102
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpriteAtlasPacker", "SpriteAtlasPacker\SpriteAtlasPacker.csproj", "{1AC0A15F-98D2-477D-A620-A8F7B79935F4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SpriteAtlasPacker", "SpriteAtlasPacker\SpriteAtlasPacker.csproj", "{1AC0A15F-98D2-477D-A620-A8F7B79935F4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpriteAtlasPacker.Tester", "SpriteAtlasPacker.Tester\SpriteAtlasPacker.Tester.csproj", "{8FE22E8A-BF39-49A9-829F-1F8C7D41B838}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SpriteAtlasPacker.Tester", "SpriteAtlasPacker.Tester\SpriteAtlasPacker.Tester.csproj", "{8FE22E8A-BF39-49A9-829F-1F8C7D41B838}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpriteAtlasPacker.Console", "SpriteAtlasPacker.Console\SpriteAtlasPacker.Console.csproj", "{76FB74CD-5CCF-4D81-9652-A0D82EB9B36C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SpriteAtlasPacker.Console", "SpriteAtlasPacker.Console\SpriteAtlasPacker.Console.csproj", "{76FB74CD-5CCF-4D81-9652-A0D82EB9B36C}"
+	ProjectSection(ProjectDependencies) = postProject
+		{1AC0A15F-98D2-477D-A620-A8F7B79935F4} = {1AC0A15F-98D2-477D-A620-A8F7B79935F4}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -32,7 +35,7 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		VisualSVNWorkingCopyRoot = .
 		SolutionGuid = {49ABCC90-34F4-4DAD-9E9C-EDA06292431F}
+		VisualSVNWorkingCopyRoot = .
 	EndGlobalSection
 EndGlobal

--- a/Nez.SpriteAtlasPacker/SpriteAtlasPacker/Exporters/AtlasMapExporter.cs
+++ b/Nez.SpriteAtlasPacker/SpriteAtlasPacker/Exporters/AtlasMapExporter.cs
@@ -48,7 +48,8 @@ namespace Nez.Tools.Atlases
 						if (origins != null)
 						{
 							var name = imagesNames[image];
-							origins.TryGetValue(name, out origin);
+							if (origins.ContainsKey(name))
+								origin = origins[name];
 						}
 						writer.WriteLine("\t{0},{1}",
 							origin.X.ToString(System.Globalization.CultureInfo.InvariantCulture),

--- a/Nez.SpriteAtlasPacker/SpriteAtlasPacker/Exporters/AtlasMapExporter.cs
+++ b/Nez.SpriteAtlasPacker/SpriteAtlasPacker/Exporters/AtlasMapExporter.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 
 namespace Nez.Tools.Atlases
 {
@@ -9,7 +10,7 @@ namespace Nez.Tools.Atlases
 	{
 		public static string MapExtension => "lua";
 
-		public static void Save(string filename, Dictionary<string, Rectangle> map, Dictionary<string, List<string>> animations, SpriteAtlasPacker.Config arguments)
+		public static void Save(string filename, Dictionary<string, Rectangle> map, Dictionary<string, List<string>> animations, Dictionary<string, Vector2> origins, SpriteAtlasPacker.Config arguments)
 		{
 			var images = new List<string>(map.Keys);
 
@@ -43,9 +44,15 @@ namespace Nez.Tools.Atlases
 					// write images origins
 					if (!arguments.NoOrigins)
 					{
+						Vector2 origin = new Vector2(arguments.OriginX, arguments.OriginY);
+						if (origins != null)
+						{
+							var name = imagesNames[image];
+							origins.TryGetValue(name, out origin);
+						}
 						writer.WriteLine("\t{0},{1}",
-							arguments.OriginX.ToString(System.Globalization.CultureInfo.InvariantCulture),
-							arguments.OriginY.ToString(System.Globalization.CultureInfo.InvariantCulture));
+							origin.X.ToString(System.Globalization.CultureInfo.InvariantCulture),
+							origin.Y.ToString(System.Globalization.CultureInfo.InvariantCulture));
 					}
 				}
 
@@ -68,6 +75,5 @@ namespace Nez.Tools.Atlases
 				}
 			}
 		}
-
 	}
 }

--- a/Nez.SpriteAtlasPacker/SpriteAtlasPacker/Importers/AtlasMapOriginsImporter.cs
+++ b/Nez.SpriteAtlasPacker/SpriteAtlasPacker/Importers/AtlasMapOriginsImporter.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Numerics;
+
+namespace Nez.Tools.Atlases
+{
+	public static class AtlasMapOriginsImporter
+	{
+
+		/// <summary>
+		/// parses a .atlas file and extract sprite origins
+		/// </summary>
+		public static Dictionary<string, Vector2> ImportFromFile(string dataFile)
+		{
+			var origins = new Dictionary<string, Vector2>();
+
+			var commaSplitter = new char[] { ',' };
+
+			string line = null;
+			using (var streamFile = File.OpenRead(dataFile))
+			{
+				using (var stream = new StreamReader(streamFile))
+				{
+					while ((line = stream.ReadLine()) != null)
+					{
+						// once we hit an empty line we are done parsing sprites and origins
+						if (string.IsNullOrWhiteSpace(line))
+							break;
+
+						var name = line;
+
+						// source rect
+						line = stream.ReadLine();
+
+						// origin
+						line = stream.ReadLine();
+						var lineParts = line.Split(commaSplitter, StringSplitOptions.RemoveEmptyEntries);
+						var origin = new Vector2(float.Parse(lineParts[0], System.Globalization.CultureInfo.InvariantCulture), float.Parse(lineParts[1], System.Globalization.CultureInfo.InvariantCulture));
+
+						origins[name] = origin;
+					}
+				}
+			}
+			return origins;
+		}
+	}
+}

--- a/Nez.SpriteAtlasPacker/SpriteAtlasPacker/Properties/launchSettings.json
+++ b/Nez.SpriteAtlasPacker/SpriteAtlasPacker/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "SpriteAtlasPacker": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/Nez.SpriteAtlasPacker/SpriteAtlasPacker/SpriteAtlasPacker.cs
+++ b/Nez.SpriteAtlasPacker/SpriteAtlasPacker/SpriteAtlasPacker.cs
@@ -94,7 +94,12 @@ namespace Nez.Tools.Atlases
 			}
 
 			// load origins if atlas file is passed in config
-			var origins = AtlasMapOriginsImporter.ImportFromFile(config.MapInputFile);
+			Dictionary<string, System.Numerics.Vector2> origins = null;
+
+			if (File.Exists(config.MapInputFile))
+				origins = AtlasMapOriginsImporter.ImportFromFile(config.MapInputFile);
+			else
+				System.Console.WriteLine("Input map file does not exist, using default origins.");
 
 			if (config.OutputLua)
 				config.MapOutputFile = config.MapOutputFile.Replace(".atlas", ".lua");

--- a/Nez.SpriteAtlasPacker/SpriteAtlasPacker/SpriteAtlasPacker.cs
+++ b/Nez.SpriteAtlasPacker/SpriteAtlasPacker/SpriteAtlasPacker.cs
@@ -22,6 +22,7 @@ namespace Nez.Tools.Atlases
 		public class Config
 		{
 			public string AtlasOutputFile;
+			public string MapInputFile;
 			public string MapOutputFile;
 			public int AtlasMaxWidth = Constants.DefaultMaximumSheetWidth;
 			public int AtlasMaxHeight = Constants.DefaultMaximumSheetHeight;
@@ -92,6 +93,9 @@ namespace Nez.Tools.Atlases
 					throw new Exception("Invalid image format for output image.");
 			}
 
+			// load origins if atlas file is passed in config
+			var origins = AtlasMapOriginsImporter.ImportFromFile(config.MapInputFile);
+
 			if (config.OutputLua)
 				config.MapOutputFile = config.MapOutputFile.Replace(".atlas", ".lua");
 
@@ -101,7 +105,7 @@ namespace Nez.Tools.Atlases
 			if (config.OutputLua)
 				LuaMapExporter.Save(config.MapOutputFile, outputMap, animations, outputImage.Width, outputImage.Height, config);
 			else
-				AtlasMapExporter.Save(config.MapOutputFile, outputMap, animations, config);
+				AtlasMapExporter.Save(config.MapOutputFile, outputMap, animations, origins, config);
 
 			return 0;
 		}


### PR DESCRIPTION
SpriteAtlasPacker was using the default origin (0.5,0.5) for all the sprites added to atlas, not using the values changed by the user (e.g. to 0.5,1 in isometric game). Following changes use the original .atlas file and extracts the Origins for the sprites from the file, which is improving greatly workflow of adding new sprites to the game.