### PR TITLE
TypeNameHandling.Auto works now for object fields

### DIFF
--- a/Nez.Persistence/Json/JsonEncoder.cs
+++ b/Nez.Persistence/Json/JsonEncoder.cs
@@ -202,7 +202,14 @@ namespace Nez.Persistence
 				WriteValueDelimiter();
 				EncodeString(field.Name);
 				AppendColon();
-				EncodeValue(field.GetValue(value));
+
+				var fieldValue = field.GetValue(value);
+				bool forceTypeHintForField = false;
+				if(fieldValue != null && _settings.TypeNameHandling == TypeNameHandling.Auto)
+					if(field.FieldType != fieldValue.GetType())
+						forceTypeHintForField = true;
+				
+				EncodeValue(fieldValue, forceTypeHintForField);
 			}
 
 			foreach (var property in _cacheResolver.GetEncodablePropertiesForType(type))


### PR DESCRIPTION
Fix for this issue:

```csharp
class Shape { 
  int x; 
  int y; 
}

class Rectangle { 
  int width; 
  int height; 
}

class ThingToSerialize 
{
  // JsonEncoder currently serializes this as a Shape when using TypeNameHandling.Auto
  Shape MyShape = new Rectangle(); 
}
```