### PR TITLE
TiledMapLoader fix for a recent update of Tiled that changed field name

### DIFF
--- a/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
@@ -409,7 +409,7 @@ namespace Nez.Tiled
 			obj.Y = (float)xObject.Attribute("y");
 			obj.Width = (float?)xObject.Attribute("width") ?? 0.0f;
 			obj.Height = (float?)xObject.Attribute("height") ?? 0.0f;
-			obj.Type = (string)xObject.Attribute("type") ?? string.Empty;
+			obj.Type = (string)xObject.Attribute("type") ?? (string)xObject.Attribute("class") ?? string.Empty;
 			obj.Visible = (bool?)xObject.Attribute("visible") ?? true;
 			obj.Rotation = (float?)xObject.Attribute("rotation") ?? 0.0f;
 


### PR DESCRIPTION
A recent update to Tiled (I think 1.8?) changed filed name "type" on an object to "class", breaking object loading that tries to parse that field for any maps saved with that version of higher.  Updated TiledMapLoader to support both so objects will parse correctly in both old and new versions of Tiled.