### PR TITLE
fix FramesPerSecond component crash when no time passed at all

### DIFF
--- a/Nez.Portable/ECS/Components/Text/FramesPerSecondCounter.cs
+++ b/Nez.Portable/ECS/Components/Text/FramesPerSecondCounter.cs
@@ -121,6 +121,8 @@ namespace Nez
 
 		public virtual void Update()
 		{
+			if (Time.UnscaledDeltaTime == 0.0f)
+				return;
 			CurrentFramesPerSecond = 1.0f / Time.UnscaledDeltaTime;
 			_sampleBuffer.Enqueue(CurrentFramesPerSecond);
 


### PR DESCRIPTION
Simple Fix for #731 