### PR TITLE
Collider no longer registers with physics system when disabled

### DIFF
--- a/Nez.Portable/ECS/Components/Physics/Colliders/Collider.cs
+++ b/Nez.Portable/ECS/Components/Physics/Colliders/Collider.cs
@@ -114,11 +114,13 @@ namespace Nez
 		{
 			if (_localOffset != offset)
 			{
-				UnregisterColliderWithPhysicsSystem();
+				if(Enabled)
+					UnregisterColliderWithPhysicsSystem();
 				_localOffset = offset;
 				_localOffsetLength = _localOffset.Length();
 				_isPositionDirty = true;
-				RegisterColliderWithPhysicsSystem();
+				if(Enabled)
+					RegisterColliderWithPhysicsSystem();
 			}
 
 			return this;
@@ -183,7 +185,8 @@ namespace Nez
 			}
 
 			_isParentEntityAddedToScene = true;
-			RegisterColliderWithPhysicsSystem();
+			if(Enabled)
+				RegisterColliderWithPhysicsSystem();
 		}
 
 


### PR DESCRIPTION
There are a couple of situations where a Collider will register itself with the physics system when it's disabled. This can cause phantom collisions, which has resulted in the acceleration of a certain programmer's descent into madness.

Example 1:
```cs
var collider = entity.AddComponent(new Collider());
collider.Enabled = false;
// later, once entity.Update() is called, the collider will be added to the entity's component list
// and RegisterColliderWithPhysicsSystem() is called, ignoring collider.Enabled
```
Example 2:
```cs
collider.Enabled = false;

// SetLocalOffset ignores collider.Enabled and re-registers it with the physics system.
collider.SetLocalOffset(Vector2.Zero); 
```