### PR TITLE
Use relative path for root assets

### DIFF
--- a/T4Templates/ContentPathGenerator.tt
+++ b/T4Templates/ContentPathGenerator.tt
@@ -43,7 +43,7 @@ namespace Nez
 		}
 
 		// handle any files in the root sourceFolder
-		PrintContentFiles( Host.ResolvePath( sourceFolder ), 2, Host.ResolvePath( sourceFolder ) );
+		PrintContentFiles( Host.ResolvePath( sourceFolder ), 2, sourceFolder );
 	}
 
 #>


### PR DESCRIPTION
The current `ContenPathGenerator.tt` template spits out a full path for assets in the root source folders:

```
class Content
{
    public const string Cursor = @"C:\Users\user\GitHub\MyGame\MainProject\Content\cursor.png";
}
```

This is problematic because now references will not be portable. They should instead be relative. After making the change the generated file now prints the following for assets in the root source folder:

```
class Content
{
    public const string Cursor = @"Content\cursor.png";
}
```

Tested on VS 2022 on Windows 11