### PR TITLE
Add JustPushed and SetRepeat methods to VirtualIntegerAxis

### DIFF
--- a/Nez.Portable/Input/Virtual/VirtualAxis.cs
+++ b/Nez.Portable/Input/Virtual/VirtualAxis.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Microsoft.Xna.Framework.Input;
 
 
@@ -56,6 +56,25 @@ namespace Nez
 		public abstract class Node : VirtualInputNode
 		{
 			public abstract float Value { get; }
+
+			protected float _previousValue = 0;
+			protected bool _justPushed = false;
+
+			public int DirectionJustPushed => _justPushed ? System.Math.Sign(Value) : 0;
+
+			public bool JustPushed(int direction)
+			{
+				return Value == direction && _justPushed;
+			}
+
+			public override void Update()
+			{
+				_justPushed = false;
+				if(Value != 0 && _previousValue == 0)
+					_justPushed = true;
+
+				_previousValue = Value;
+			}
 		}
 
 
@@ -248,6 +267,13 @@ namespace Nez
 					_turned = false;
 					_value = 0;
 				}
+
+				_justPushed = false;
+				if(_value != 0 && _previousValue == 0)
+				{
+					_justPushed = true;
+				}
+				_previousValue = Value;
 			}
 
 


### PR DESCRIPTION
Adds a `bool JustPushed(int direction)` method and `int DirectionJustPushed` property to VirtualIntegerAxis, which function similarly to `VirtualButton.IsPressed`. 

Also adds repeating input support to VirtualIntegerAxis, which allows JustPushed to repeatedly fire when set up with the new `SetRepeat` methods -- this again functions the same as VirtualButton's repeating input.

These features are super useful for UI, i.e. navigating through menu options with a gamepad control stick.