### PR TITLE
Respect sprite rounding in both implementations of Batcher.PushSprite()

### DIFF
--- a/Nez.Portable/Graphics/Batcher/Batcher.cs
+++ b/Nez.Portable/Graphics/Batcher/Batcher.cs
@@ -852,6 +852,12 @@ namespace Nez
 			if (_numSprites >= MAX_SPRITES)
 				FlushBatch();
 
+			if (!_shouldIgnoreRoundingDestinations && ShouldRoundDestinations)
+			{
+				destinationX = Mathf.Round(destinationX);
+				destinationY = Mathf.Round(destinationY);
+			}
+
 			// Source/Destination/Origin Calculations. destinationW/H is the scale value so we multiply by the size of the texture region
 			var originX = (origin.X / sprite.Uvs.Width) / sprite.Texture2D.Width;
 			var originY = (origin.Y / sprite.Uvs.Height) / sprite.Texture2D.Height;


### PR DESCRIPTION
Resolves #761 

All I've done here is taken the destination rounding code from the Texture2D implementation of PushSprite and placed it in the Sprite implementation.