### PR TITLE
HardwareModeSwitch is MG38 only.

### DIFF
--- a/Nez.Portable/Core.cs
+++ b/Nez.Portable/Core.cs
@@ -146,8 +146,8 @@ namespace Nez
 				PreferredBackBufferHeight = height,
 				IsFullScreen = isFullScreen,
 				SynchronizeWithVerticalRetrace = true,
-				HardwareModeSwitch = hardwareModeSwitch,
 #if MONOGAME_38
+				HardwareModeSwitch = hardwareModeSwitch,
 				PreferHalfPixelOffset = true
 #endif
 			};

--- a/Nez.Portable/Utils/Screen.cs
+++ b/Nez.Portable/Utils/Screen.cs
@@ -87,6 +87,14 @@ namespace Nez
 			set => _graphicsManager.IsFullScreen = value;
 		}
 
+#if MONOGAME_38
+		public static bool HardwareModeSwitch
+		{
+			get => _graphicsManager.HardwareModeSwitch;
+			set => _graphicsManager.HardwareModeSwitch = value;
+		}
+#endif
+
 		public static DisplayOrientation SupportedOrientations
 		{
 			get => _graphicsManager.SupportedOrientations;


### PR DESCRIPTION
Fixes change from earlier commit about HardwareModeSwitch.
It's only available in MG38, so it should be in that macro block.
Also added getter from HardwareModeSwitch to coincide with the other graphics manager fields.

This is a new PR because the old one included a commit that it should not have.