### PR TITLE
Fix outdated spelling for Core.RegisterGlobalManager in Documentation

### DIFF
--- a/Nez.ImGui/README.md
+++ b/Nez.ImGui/README.md
@@ -5,7 +5,7 @@ Dear ImGui is available via the Nez.ImGui project. The API is a wip and will be 
 
 ```csharp
 var imGuiManager = new ImGuiManager();
-Core.registerGlobalManager( imGuiManager );
+Core.RegisterGlobalManager( imGuiManager );
 
 // toggle ImGui rendering on/off. It starts out enabled.
 imGuiManager.setEnabled( false );

--- a/Nez.ImGui/README.md
+++ b/Nez.ImGui/README.md
@@ -8,7 +8,7 @@ var imGuiManager = new ImGuiManager();
 Core.RegisterGlobalManager( imGuiManager );
 
 // toggle ImGui rendering on/off. It starts out enabled.
-imGuiManager.setEnabled( false );
+imGuiManager.SetEnabled( false );
 ```
 
 


### PR DESCRIPTION
The function `RegisterGlobalManager' is now in PascalCase and not camelCase as seen in the file [Core.cs](https://github.com/prime31/Nez/blob/a1cd7fc5d7ff9a205f89a87a6198b43dc09148b2/Nez.Portable/Core.cs#L405C38-L405C38)