### PR TITLE
Added per frame framerate

### DIFF
--- a/Nez.Portable/Assets/SpriteAtlases/SpriteAnimation.cs
+++ b/Nez.Portable/Assets/SpriteAtlases/SpriteAnimation.cs
@@ -1,16 +1,27 @@
-﻿using Nez.Textures;
+﻿using System;
+using Nez.Textures;
 
 namespace Nez.Sprites
 {
 	public class SpriteAnimation
 	{
 		public readonly Sprite[] Sprites;
-		public readonly float FrameRate;
+		public readonly float[] FrameRates;
 
 		public SpriteAnimation(Sprite[] sprites, float frameRate)
 		{
 			Sprites = sprites;
-			FrameRate = frameRate;
+			FrameRates = new float[sprites.Length];
+			for(int i = 0; i < FrameRates.Length; ++i)
+			{
+				FrameRates[i] = frameRate;
+			}
+		}
+
+		public SpriteAnimation(Sprite[] sprites, float[] frameRates)
+		{
+			Sprites = sprites;
+			FrameRates = frameRates;
 		}
 	}
 }

--- a/Nez.Portable/ECS/Components/Renderables/Sprites/SpriteAnimator.cs
+++ b/Nez.Portable/ECS/Components/Renderables/Sprites/SpriteAnimator.cs
@@ -103,7 +103,7 @@ namespace Nez.Sprites
 				return;
 
 			var animation = CurrentAnimation;
-			var secondsPerFrame = 1 / (animation.FrameRate * Speed);
+			var secondsPerFrame = 1 / (animation.FrameRates[CurrentFrame] * Speed);
 			var iterationDuration = secondsPerFrame * animation.Sprites.Length;
 			var pingPongIterationDuration = animation.Sprites.Length < 3 ? iterationDuration : secondsPerFrame * (animation.Sprites.Length * 2 - 2);
 


### PR DESCRIPTION
This adds the option to specify a framerate/delay per frame instead of a single framerate for an entire animation. This is in preparation for adding Aseprite support.

`for` loop is used to populate the array in the original constructor instead of `Enumerable.Repeat` because it's faster (Do I need to justify this?) and `++i` instead of `i++` since we don't need the copy. I believe compiler would optimize this anyway, so feel free to tell me to change it to `i++` if preferred. 