### PR TITLE
Add rotation to debug render

### DIFF
--- a/Nez.Portable/Assets/Tiled/Runtime/TiledRendering.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledRendering.cs
@@ -302,7 +302,14 @@ namespace Nez.Tiled
 				switch (obj.ObjectType)
 				{
 					case TmxObjectType.Basic:
-						batcher.DrawHollowRect(pos, obj.Width * scale.X, obj.Height * scale.Y, objGroup.Color);
+						if(obj.Rotation != 0)
+						{
+							batcher.DrawHollowRect(pos, obj.Width * scale.X, obj.Height * scale.Y, objGroup.Color, Mathf.Radians(obj.Rotation), pos);
+						}
+						else
+						{
+							batcher.DrawHollowRect(pos, obj.Width * scale.X, obj.Height * scale.Y, objGroup.Color);
+						}
 						goto default;
 					case TmxObjectType.Point:
 						var size = objGroup.Map.TileWidth * 0.5f;

--- a/Nez.Portable/Graphics/Batcher/BatcherDrawingExt.cs
+++ b/Nez.Portable/Graphics/Batcher/BatcherDrawingExt.cs
@@ -197,6 +197,42 @@ namespace Nez
 			batcher.Draw(Graphics.Instance.PixelTexture, rect, Graphics.Instance.PixelTexture.SourceRect, color);
 		}
 
+		public static void DrawHollowRect(this Batcher batcher, float x, float y, float width, float height,
+		                                  Color color, float rotation, Vector2 origin, float thickness = 1)
+		{
+			var rotor = Matrix2D.CreateTranslation(-origin);
+			rotor *= Matrix2D.CreateRotation(rotation);
+			rotor *= Matrix2D.CreateTranslation(origin);
+
+			var tl = Vector2Ext.Round(new Vector2(x, y));
+			var tr = Vector2Ext.Round(Vector2.Transform(new Vector2(x + width, y), rotor));
+			var br = Vector2Ext.Round(Vector2.Transform(new Vector2(x + width, y + height), rotor));
+			var bl = Vector2Ext.Round(Vector2.Transform(new Vector2(x, y + height), rotor));
+
+			batcher.SetIgnoreRoundingDestinations(true);
+			batcher.DrawLine(tl, tr, color, thickness);
+			batcher.DrawLine(tr, br, color, thickness);
+			batcher.DrawLine(br, bl, color, thickness);
+			batcher.DrawLine(bl, tl, color, thickness);
+			batcher.SetIgnoreRoundingDestinations(false);
+		}
+
+		public static void DrawHollowRect(this Batcher batcher, Vector2 position, float width, float height,
+		                                  Color color, float rotation, Vector2 origin, float thickness = 1)
+		{
+			DrawHollowRect(batcher, position.X, position.Y, width, height, color, rotation, origin, thickness);
+		}
+
+		public static void DrawHollowRect(this Batcher batcher, Rectangle rect, Color color, float rotation, Vector2 origin, float thickness = 1)
+		{
+			DrawHollowRect(batcher, rect.X, rect.Y, rect.Width, rect.Height, color, rotation, origin, thickness);
+		}
+
+		public static void DrawHollowRect(this Batcher batcher, RectangleF rect, Color color, float rotation, Vector2 origin, float thickness = 1)
+		{
+			DrawHollowRect(batcher, rect.X, rect.Y, rect.Width, rect.Height, color, rotation, origin, thickness);
+		}
+
 		#endregion
 
 


### PR DESCRIPTION
Add rotation and rotation origin to DrawHollowRect and use it in TiledRendering for rendering rotated basic objects in debug render. The parameter order convention follows similar methods e.g. DrawString.

The screenshot shows which case is now handled correctly: 
<img width="1838" alt="image" src="https://github.com/prime31/Nez/assets/38362995/b20f2edf-ebbc-4c41-9895-134fdd2dc498">

