### PR TITLE
Check if font file has padding defined.

### DIFF
--- a/Nez.Portable/Assets/BitmapFonts/BitmapFontLoader.cs
+++ b/Nez.Portable/Assets/BitmapFonts/BitmapFontLoader.cs
@@ -151,9 +151,9 @@ namespace Nez.BitmapFonts
 		/// <returns></returns>
 		internal static Padding ParsePadding(string s)
 		{
-			var parts = s.Split(',');
-			if (parts.Length < 4)
+			if (string.IsNullOrEmpty(s))
 				return new Padding();
+			var parts = s.Split(',');
 			return new Padding()
 			{
 				Left = Convert.ToInt32(parts[3].Trim()),

--- a/Nez.Portable/Assets/BitmapFonts/BitmapFontLoader.cs
+++ b/Nez.Portable/Assets/BitmapFonts/BitmapFontLoader.cs
@@ -152,6 +152,8 @@ namespace Nez.BitmapFonts
 		internal static Padding ParsePadding(string s)
 		{
 			var parts = s.Split(',');
+			if (parts.Length < 4)
+				return new Padding();
 			return new Padding()
 			{
 				Left = Convert.ToInt32(parts[3].Trim()),
@@ -230,7 +232,7 @@ namespace Nez.BitmapFonts
 				return parts.ToArray();
 			}
 
-			return s.Split(new char[] {delimiter}, StringSplitOptions.RemoveEmptyEntries);
+			return s.Split(new char[] { delimiter }, StringSplitOptions.RemoveEmptyEntries);
 		}
 
 		/// <summary>


### PR DESCRIPTION
I ran into a problem where a .fnt file I had generated could not be read by Nez, and I figured out the issue was that the generated file had no parameter for `padding` defined, I guess since I had set padding to 0, that specific program defaulted to not including the parameter at all. Nez should probably check if the padding parameter is there before trying to read from it.