### PR TITLE
Prevent SetGamepadFocusElement() from dropping focus when the target element already holds it

### DIFF
--- a/Nez.Portable/UI/Stage.cs
+++ b/Nez.Portable/UI/Stage.cs
@@ -686,6 +686,9 @@ namespace Nez.UI
 		{
 			_isGamepadFocusEnabled = true;
 
+			if (_gamepadFocusElement == focusable)
+				return;
+
 			if (focusable != null)
 				focusable.OnFocused();
 


### PR DESCRIPTION
Calling `SetGamepadFocusElement` with a target that already has gamepad focus causes focus to be lost.  This is because the function first puts focus on the new element, then unfocuses the previous element.  If they're the same element, the result is focus is dropped.

The fix is just to skip the focus/unfocus logic if the new target is the already focused element.  This is the same check that `SetKeyboardFocus` uses.