### PR TITLE
Fix/aseprite linked cel

### DIFF
--- a/Nez.Portable/Assets/Aseprite/AsepriteFrame.cs
+++ b/Nez.Portable/Assets/Aseprite/AsepriteFrame.cs
@@ -78,7 +78,14 @@ namespace Nez.Aseprite
 				//	Note: Will look into adding tilemap cels in a future PR if it is requested enough or if someone
 				//	else wants to add it in.  You can see how I do it in my MonoGame.Aseprite library for reference if
 				//	needed.
-				if (cel is AsepriteImageCel imageCel)
+			CheckCelType:
+				if(cel is AsepriteLinkedCel linkedCel)
+				{
+					cel = linkedCel.Cel;
+					goto CheckCelType;
+				}
+
+				if(cel is AsepriteImageCel imageCel)
 				{
 					BlendCel(backdrop: result,
 							 source: imageCel.Pixels,

--- a/Nez.Portable/Assets/Aseprite/Loader/AsepriteFileLoader.cs
+++ b/Nez.Portable/Assets/Aseprite/Loader/AsepriteFileLoader.cs
@@ -300,9 +300,7 @@ namespace Nez.Aseprite
 									{
 										ushort linkedFrameIndex = reader.ReadWord();
 
-										//  Base off of layer index not cel index ensure that it doesn't go below zero
-										int celIndex = celLayerIndex > 0 ? celLayerIndex - 1 : 0;
-										AsepriteCel otherCel = frames[linkedFrameIndex].Cels[celIndex];
+										AsepriteCel otherCel = frames[linkedFrameIndex].Cels[cels.Count];
 										cel = new AsepriteLinkedCel(otherCel, celLayer, celPosition, celOpacity);
 									}
 									break;


### PR DESCRIPTION
This PR resolves two issue
- Aseprite files with linked cels were throwing an exception due to pulling the incorrect cel index from the reference cel.
- `FlattenFrame` correctly checks for `AsepriteLinkedCel` now and use it if the linked cel is an `AsepriteImageCel`