### PR TITLE
Expose `AsepriteFileLoader.ReadAsepriteFile` publicly

### DIFF
--- a/Nez.Portable/Assets/Aseprite/Loader/AsepriteFileLoader.cs
+++ b/Nez.Portable/Assets/Aseprite/Loader/AsepriteFileLoader.cs
@@ -90,7 +90,7 @@ namespace Nez.Aseprite
 			}
 		}
 
-		private static AsepriteFile ReadAsepriteFile(this BinaryReader reader, string name, bool premultiplyAlpha)
+		public static AsepriteFile ReadAsepriteFile(this BinaryReader reader, string name, bool premultiplyAlpha)
 		{
 			reader.BaseStream.Seek(0, SeekOrigin.Begin);
 


### PR DESCRIPTION
Due to `AsepriteFileLoader.Load` using `TitleContainer.OpenStream` you can't currently read an Aseprite file using an absolute path (e.g. in a Content Pipeline) or one that you have in memory.