### PR TITLE
Adds TryLoad Method to AsepriteFileLoader

### DIFF
--- a/Nez.Portable/Assets/Aseprite/Loader/AsepriteFileLoader.cs
+++ b/Nez.Portable/Assets/Aseprite/Loader/AsepriteFileLoader.cs
@@ -80,6 +80,9 @@ namespace Nez.Aseprite
 		/// A new instance of the <see cref="AsepriteFile"/> class initialized with the contents read from the Aseprite
 		/// file.
 		/// </returns>
+		/// <exception cref="InvalidOperationException">
+		/// Thrown if an error occurs while attempting to read the Aseprite file. See exception message for details.
+		/// </exception>
 		public static AsepriteFile Load(string name, bool premultiplyAlpha = false)
 		{
 			using (var stream = TitleContainer.OpenStream(name))

--- a/Nez.Portable/Assets/Aseprite/Loader/AsepriteFileLoader.cs
+++ b/Nez.Portable/Assets/Aseprite/Loader/AsepriteFileLoader.cs
@@ -75,6 +75,7 @@ namespace Nez.Aseprite
 		/// <param name="premultiplyAlpha">
 		/// Indicates whether color data generated while reading the content of this Aseprite file should be
 		/// premultipled.  Default is false.
+		/// </param>
 		/// <returns>
 		/// A new instance of the <see cref="AsepriteFile"/> class initialized with the contents read from the Aseprite
 		/// file.

--- a/Nez.Portable/Assets/Aseprite/Loader/AsepriteFileLoader.cs
+++ b/Nez.Portable/Assets/Aseprite/Loader/AsepriteFileLoader.cs
@@ -91,6 +91,47 @@ namespace Nez.Aseprite
 			}
 		}
 
+		/// <summary>
+		/// Attempts to load an Aseprite (.ase/.aseprite) file and creates an instance with the contents of the file.
+		/// </summary>
+		/// <remarks>
+		/// Errors occurred while attempting to load the Aseprite file will be logged in <see cref="Debug"/> output.
+		/// </remarks>
+		/// <param name="name">The name of the Aseprite (.ase/.aseprite) file to load</param>
+		/// <param name="premultiplyAlpha">
+		/// Indicates whether color data generated while reading the content of this Aseprite file should be
+		/// premultipled.  Default is false.
+		/// </param>
+		/// <param name="file">
+		/// When this method returns, if <see langword="true"/>, contains the contents of the Aseprite file that was
+		/// loaded; otherwise, <see langword="null"/>.
+		/// </param>
+		/// <returns>
+		/// <see langword="true"/> if the contents of the Aseprite file could be loaded without any issue; otherwise,
+		/// <see langword="false"/>.
+		/// </returns>
+		public static bool TryLoad(string name, bool premultiplyAlpha, out AsepriteFile file)
+		{
+			file = null;
+
+			using (var stream = TitleContainer.OpenStream(name))
+			{
+				try
+				{
+					using (BinaryReader reader = new BinaryReader(stream))
+					{
+						file = ReadAsepriteFile(reader, name, premultiplyAlpha);
+					}
+				}
+				catch (Exception ex)
+				{
+					Debug.Error(ex.Message);
+				}
+			}
+
+			return file != null;
+		}
+
 		private static AsepriteFile ReadAsepriteFile(this BinaryReader reader, string name, bool premultiplyAlpha)
 		{
 			reader.BaseStream.Seek(0, SeekOrigin.Begin);


### PR DESCRIPTION
## Description
Adds a `TryLoad` method to the `AsepriteFileLoader`.  When calling the underlying load method, when an exception occurs, this will output the exception details in the Debug panel and return `false` instead of causing exceptions to occur.

## Motivation
The reason for this PR is as follows

![image](https://github.com/prime31/Nez/assets/103014489/7f95fb15-6fd1-4ba9-baa8-e8162c4e37ec)
