### PR TITLE
AddEntity(Entity) now calls AddEntity<T>(T) for consistency.

### DIFF
--- a/Nez.Portable/ECS/Scene.cs
+++ b/Nez.Portable/ECS/Scene.cs
@@ -993,14 +993,7 @@ namespace Nez
 		/// <param name="entity">The Entity to add</param>
 		public Entity AddEntity(Entity entity)
 		{
-			Insist.IsFalse(Entities.Contains(entity), "You are attempting to add the same entity to a scene twice: {0}", entity);
-			Entities.Add(entity);
-			entity.Scene = this;
-
-			for (var i = 0; i < entity.Transform.ChildCount; i++)
-				AddEntity(entity.Transform.GetChild(i).Entity);
-
-			return entity;
+			return AddEntity<Entity>(entity);
 		}
 
 		/// <summary>
@@ -1012,6 +1005,10 @@ namespace Nez
 			Insist.IsFalse(Entities.Contains(entity), "You are attempting to add the same entity to a scene twice: {0}", entity);
 			Entities.Add(entity);
 			entity.Scene = this;
+
+			for (var i = 0; i < entity.Transform.ChildCount; i++)
+				AddEntity<Entity>(entity.Transform.GetChild(i).Entity);
+			
 			return entity;
 		}
 


### PR DESCRIPTION
Previously, `AddEntity` would add the entity's children to the scene while `AddEntity<T>` doesn't. This fixes that, and now `AddEntity` simply calls `AddEntity<T>` to ensure consistency.