### PR TITLE
Object allocation of IEnumator caused memory leak

### DIFF
--- a/Nez.Portable/Assets/Tiled/TiledTypes/Map.cs
+++ b/Nez.Portable/Assets/Tiled/TiledTypes/Map.cs
@@ -54,10 +54,11 @@ namespace Nez.Tiled
         /// <summary>
         /// currently only used to tick all the Tilesets so they can update their animated tiles
         /// </summary>
-        public void Update()
-        {
-            foreach (var tileset in Tilesets)
-                tileset.Update();
+        public void Update() {
+	        for (var i = 0; i < Tilesets.Count; i++) {
+		        var tileset = Tilesets[i];
+		        tileset.Update();
+	        }
         }
 
 		#region IDisposable Support
@@ -68,13 +69,16 @@ namespace Nez.Tiled
 		{
 			if (!_isDisposed)
 			{
-				if (disposing)
-				{
-					foreach (var tileset in Tilesets)
+				if (disposing) {
+					for (var i = 0; i < Tilesets.Count; i++) {
+						var tileset = Tilesets[i];
 						tileset.Image?.Dispose();
+					}
 
-					foreach (var layer in ImageLayers)
+					for (var i = 0; i < ImageLayers.Count; i++) {
+						var layer = ImageLayers[i];
 						layer.Image?.Dispose();
+					}
 				}
 
 				_isDisposed = true;

--- a/Nez.Portable/Assets/Tiled/TiledTypes/Map.cs
+++ b/Nez.Portable/Assets/Tiled/TiledTypes/Map.cs
@@ -56,8 +56,7 @@ namespace Nez.Tiled
         /// </summary>
         public void Update() {
 	        for (var i = 0; i < Tilesets.Count; i++) {
-		        var tileset = Tilesets[i];
-		        tileset.Update();
+		        Tilesets[i].Update();
 	        }
         }
 
@@ -71,13 +70,11 @@ namespace Nez.Tiled
 			{
 				if (disposing) {
 					for (var i = 0; i < Tilesets.Count; i++) {
-						var tileset = Tilesets[i];
-						tileset.Image?.Dispose();
+						Tilesets[i].Image?.Dispose();
 					}
 
 					for (var i = 0; i < ImageLayers.Count; i++) {
-						var layer = ImageLayers[i];
-						layer.Image?.Dispose();
+						ImageLayers[i].Image?.Dispose();
 					}
 				}
 


### PR DESCRIPTION
Hello,

I loaded a TmxMap with some animated tiles. The number of allocated memory steadily increased.
After changing "foreach (var tileset in Tilesets)" to " for (var i = 0; i < Tilesets.Count; i++)" the allocated memory is stable.

It would be great if you could have a look at this issue and maybe allow to merge the pull request.

Best regards,
stallratte