### PR TITLE
RenderObjectGroup: Object allocation of IEnumator caused memory leak

### DIFF
--- a/Nez.Portable/Assets/Tiled/Runtime/TiledRendering.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledRendering.cs
@@ -20,8 +20,10 @@ namespace Nez.Tiled
 		/// <param name="cameraClipBounds"></param>
 		public static void RenderMap(TmxMap map, Batcher batcher, Vector2 position, Vector2 scale, float layerDepth, RectangleF cameraClipBounds)
 		{
-			foreach (var layer in map.Layers)
+			for (var index = 0; index < map.Layers.Count; index++)
 			{
+				var layer = map.Layers[index];
+				
 				if (layer is TmxLayer tmxLayer && tmxLayer.Visible)
 					RenderLayer(tmxLayer, batcher, position, scale, layerDepth, cameraClipBounds);
 				else if (layer is TmxImageLayer tmxImageLayer && tmxImageLayer.Visible)
@@ -286,8 +288,10 @@ namespace Nez.Tiled
 			if (!objGroup.Visible)
 				return;
 
-			foreach (var obj in objGroup.Objects)
+			for (var index = 0; index < objGroup.Objects.Count; index++)
 			{
+				var obj = objGroup.Objects[index];
+				
 				if (!obj.Visible)
 					continue;
 
@@ -371,8 +375,10 @@ namespace Nez.Tiled
 			if (!group.Visible)
 				return;
 
-			foreach (var layer in group.Layers)
+			for (var index = 0; index < group.Layers.Count; index++)
 			{
+				var layer = group.Layers[index];
+				
 				if (layer is TmxGroup tmxSubGroup)
 					RenderGroup(tmxSubGroup, batcher, position, scale, layerDepth);
 

--- a/Nez.Portable/ECS/Scene.cs
+++ b/Nez.Portable/ECS/Scene.cs
@@ -366,6 +366,7 @@ namespace Nez
 
 			// now we can remove the Entities and finally the SceneComponents
 			Core.Emitter.RemoveObserver(CoreEvents.GraphicsDeviceReset, OnGraphicsDeviceReset);
+			Core.Emitter.RemoveObserver(CoreEvents.OrientationChanged, OnOrientationChanged);
 			Entities.RemoveAllEntities();
 
 			for (var i = 0; i < _sceneComponents.Length; i++)


### PR DESCRIPTION
Hello,

I added an ObjectLayer to a map in Tiled. The allocated heap memory increased steadily increased after adding the ObjectLayer to the layers to render.
The object allocation of IEnumerator (foreach-loop) in TiledRendering#RenderObjectGroup causes this issue. 

Here's a screenshot of the profiled memory which shows the memory growth after a few minutes:
![memory_alloc_render_object_group](https://github.com/prime31/Nez/assets/48615771/00eff088-0481-406c-87c0-c1bd01b902fd)


With this fix the heap memory is stable.

Best regards,
stallratte
