### PR TITLE
UI: Fixed container alignment and label padding

### DIFF
--- a/Nez.Portable/ECS/Components/Renderables/Sprites/NinePatchSpriteRenderer.cs
+++ b/Nez.Portable/ECS/Components/Renderables/Sprites/NinePatchSpriteRenderer.cs
@@ -6,7 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Nez
 {
-	public class NineSliceSpriteRenderer : SpriteRenderer
+	public class NinePatchSpriteRenderer : SpriteRenderer
 	{
 		public new float Width
 		{
@@ -56,16 +56,16 @@ namespace Nez
 		bool _destRectsDirty = true;
 
 
-		public NineSliceSpriteRenderer(NinePatchSprite sprite) : base(sprite)
+		public NinePatchSpriteRenderer(NinePatchSprite sprite) : base(sprite)
 		{
 			Sprite = sprite;
 		}
 
-		public NineSliceSpriteRenderer(Sprite sprite, int top, int bottom, int left, int right) : this(
+		public NinePatchSpriteRenderer(Sprite sprite, int top, int bottom, int left, int right) : this(
 			new NinePatchSprite(sprite, left, right, top, bottom))
 		{ }
 
-		public NineSliceSpriteRenderer(Texture2D texture, int top, int bottom, int left, int right) : this(
+		public NinePatchSpriteRenderer(Texture2D texture, int top, int bottom, int left, int right) : this(
 			new NinePatchSprite(texture, left, right, top, bottom))
 		{ }
 

--- a/Nez.Portable/UI/Containers/Container.cs
+++ b/Nez.Portable/UI/Containers/Container.cs
@@ -153,9 +153,9 @@ namespace Nez.UI
 			if (_element == null)
 				return;
 
-			float padLeft = _padLeft.Get(this), padBottom = _padBottom.Get(this);
+			float padLeft = _padLeft.Get(this), padBottom = _padBottom.Get(this), padTop = _padTop.Get(this);
 			float containerWidth = GetWidth() - padLeft - _padRight.Get(this);
-			float containerHeight = GetHeight() - padBottom - _padTop.Get(this);
+			float containerHeight = GetHeight() - padBottom - padTop;
 			float minWidth = _minWidthValue.Get(_element), minHeight = _minHeightValue.Get(_element);
 			float prefWidth = _prefWidthValue.Get(_element), prefHeight = _prefHeightValue.Get(_element);
 			float maxWidth = _maxWidthValue.Get(_element), maxHeight = _maxHeightValue.Get(_element);
@@ -187,10 +187,10 @@ namespace Nez.UI
 			else if ((_align & AlignInternal.Left) == 0) // center
 				x += (containerWidth - width) / 2;
 
-			var y = padBottom;
-			if ((_align & AlignInternal.Top) != 0)
+			var y = padTop;
+			if ((_align & AlignInternal.Bottom) != 0)
 				y += containerHeight - height;
-			else if ((_align & AlignInternal.Bottom) == 0) // center
+			else if ((_align & AlignInternal.Top) == 0) // center
 				y += (containerHeight - height) / 2;
 
 			if (_round)

--- a/Nez.Portable/UI/Widgets/Label.cs
+++ b/Nez.Portable/UI/Widgets/Label.cs
@@ -295,20 +295,21 @@ namespace Nez.UI
 				}
 			}
 
-			var width = this.width;
-			var height = this.height;
-			_textPosition.X = 0;
-			_textPosition.Y = 0;
+			float paddingLeft = 0;
+			float paddingRight = 0;
+			float paddingTop = 0;
+			float paddingBottom = 0;
 
-			// TODO: explore why descent causes mis-alignment
-			//_textPosition.Y =_style.font.descent;
 			if (_style.Background != null)
 			{
-				_textPosition.X = _style.Background.LeftWidth;
-				_textPosition.Y = _style.Background.TopHeight;
-				width -= _style.Background.LeftWidth + _style.Background.RightWidth;
-				height -= _style.Background.TopHeight + _style.Background.BottomHeight;
+				paddingLeft = _style.Background.LeftWidth;
+				paddingRight = _style.Background.RightWidth;
+				paddingTop = _style.Background.TopHeight;
+				paddingBottom = _style.Background.BottomHeight;
 			}
+			
+			// TODO: explore why descent causes mis-alignment
+			//_textPosition.Y =_style.font.descent;
 
 			float textWidth, textHeight;
 			if (isWrapped || _wrappedString.IndexOf('\n') != -1)
@@ -316,45 +317,44 @@ namespace Nez.UI
 				// If the text can span multiple lines, determine the text's actual size so it can be aligned within the label.
 				textWidth = _prefSize.X;
 				textHeight = _prefSize.Y;
-
-				if ((labelAlign & AlignInternal.Left) == 0)
-				{
-					if ((labelAlign & AlignInternal.Right) != 0)
-						_textPosition.X += width - textWidth;
-					else
-						_textPosition.X += (width - textWidth) / 2;
-				}
 			}
 			else
 			{
-				textWidth = width;
+				textWidth = width - (paddingLeft + paddingRight);
 				textHeight = _style.Font.LineHeight * _style.FontScaleY;
 			}
+			
+			_textPosition.Y = 0;
 
+			// Bottom | BottomLeft | BottomRight
 			if ((labelAlign & AlignInternal.Bottom) != 0)
 			{
-				_textPosition.Y += height - textHeight;
+				_textPosition.Y = height - paddingBottom - textHeight;
 				y += _style.Font.Padding.Bottom;
 			}
+			// Top | TopLeft | TopRight
 			else if ((labelAlign & AlignInternal.Top) != 0)
 			{
-				_textPosition.Y += 0;
+				_textPosition.Y = paddingTop;
 				y -= _style.Font.Padding.Bottom;
 			}
+			// Center | Left | Right
 			else
 			{
-				_textPosition.Y += (height - textHeight) / 2;
+				_textPosition.Y = paddingTop + (height - (paddingTop + paddingBottom) - textHeight) / 2;
 			}
 
-			//_textPosition.Y += textHeight;
+			_textPosition.X = 0;
 
-			// if we have GlyphLayout this code is redundant
+			// Left | TopLeft | BottomLeft
 			if ((labelAlign & AlignInternal.Left) != 0)
-				_textPosition.X = 0;
-			else if (labelAlign == AlignInternal.Center)
-				_textPosition.X = width / 2 - (_prefSize.X / 2); // center of width - center of text size
+				_textPosition.X = paddingLeft;
+			// Right | TopRight | BottomRight
+			else if ((labelAlign & AlignInternal.Right) != 0)
+				_textPosition.X = width - paddingRight - textWidth;
+			// Center | Top | Bottom
 			else
-				_textPosition.X = width - _prefSize.X; // full width - our text size
+				_textPosition.X = paddingLeft + (width - (paddingLeft + paddingRight) - textWidth) / 2;
 		}
 
 


### PR DESCRIPTION
Hello,

I fixed two bugs.

### 1) The top and bottom alignment of the Container is swapped.

Example setup:
```csharp
public class MyUiScene : Scene {
	public override void Initialize() {
		ClearColor = Color.CornflowerBlue;

		var uiCanvas = CreateEntity("ui-canvas");
		uiCanvas.AddComponent(new MyUICanvas());
	}

	private class MyUICanvas : UICanvas {
		public override void Initialize() {
			Stage.SetDebugAll(true);

			var primitiveDrawable = new PrimitiveDrawable(Color.Brown);
			primitiveDrawable.MinWidth = 200;
			primitiveDrawable.MinHeight = 50;

			var container = Stage.AddElement(new Container(new Image(primitiveDrawable))).SetAlign(Align.Bottom).SetPadBottom(10);
			container.FillParent = true;
		}
	}
}
```

Screenshots:
![container_fix](https://github.com/prime31/Nez/assets/48615771/88fa98b7-1410-415f-aff8-db00654adc08)

### 1) Label ignores (left) padding

At the end of the Layout()-method, all previous calculation done to_textPosition.X is overridden:
https://github.com/prime31/Nez/blob/033ce7f48ed5aef6a54d6ea8a5696dcbfd07dde5/Nez.Portable/UI/Widgets/Label.cs#L352-L357

I refactored the code a little bit to make it easier to understand.

Example setup:
```csharp
public class MyUiScene : Scene {
	public override void Initialize() {
		ClearColor = Color.CornflowerBlue;

		var uiCanvas = CreateEntity("ui-canvas");
		uiCanvas.AddComponent(new MyUICanvas());
	}

	private class MyUICanvas : UICanvas {
		public override void Initialize() {
			Stage.SetDebugAll(true);

			var primitiveDrawable = new PrimitiveDrawable(Color.Brown);
			primitiveDrawable.SetPadding(0, 0, 5, 5);

			var label = new Label("Some text", new LabelStyle {
				FontScale = 6,
				Background = primitiveDrawable
			});
			var container = Stage.AddElement(new Container(label)).SetAlign(Align.Center);
			container.FillParent = true;
		}
	}
}


public class MyUiScene : Scene {
	public override void Initialize() {
		ClearColor = Color.CornflowerBlue;

		var uiCanvas = CreateEntity("ui-canvas");
		uiCanvas.AddComponent(new MyUICanvas());
	}

	private class MyUICanvas : UICanvas {
		public override void Initialize() {
			Stage.SetDebugAll(true);

			var primitiveDrawable = new PrimitiveDrawable(Color.Brown);
			primitiveDrawable.SetPadding(0, 0, 20, 20);

			var label = new Label("Some more text", new LabelStyle {
				FontScale = 6,
				Background = primitiveDrawable
			});
			label.SetWrap(true);
			var container = Stage.AddElement(new Container(label)).SetAlign(Align.Center);
			container.SetWidth(200);
			container.FillParent = true;
		}
	}
}
```

Screenshots:
![label_fix](https://github.com/prime31/Nez/assets/48615771/f3a08eb0-51b8-4f27-b30d-618fc3c943f0)


Lastly I renamed NineSliceSpriteRenderer to match the name of the class it renders.

Best regards,
stallratte