### PR TITLE
Tile layer memory consumption

### DIFF
--- a/Nez.Portable/Assets/Tiled/Runtime/Layer.Runtime.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/Layer.Runtime.cs
@@ -5,13 +5,26 @@ namespace Nez.Tiled
 {
     public partial class TmxLayer : ITmxLayer
     {
-        /// <summary>
-		/// gets the TmxLayerTile at the x/y coordinates. Note that these are tile coordinates not world coordinates!
-		/// </summary>
-		/// <returns>The tile.</returns>
-		/// <param name="x">The x coordinate.</param>
-		/// <param name="y">The y coordinate.</param>
-		public TmxLayerTile GetTile(int x, int y) => Tiles[x + y * Width];
+
+	    /// <summary>
+	    /// gets the TmxLayerTile at the x/y coordinates. Note that these are tile coordinates not world coordinates!
+	    /// </summary>
+	    /// <returns>The tile.</returns>
+	    /// <param name="x">The x coordinate.</param>
+	    /// <param name="y">The y coordinate.</param>
+	    public TmxLayerTile GetTile(int x, int y) 
+	    {
+		    Tiles.TryGetValue(Grid[x + y * Width], out var tmxLayerTile);
+
+		    return tmxLayerTile;
+	    }
+	    
+	    public TmxLayerTile GetTile(int index) 
+	    {
+		    Tiles.TryGetValue(Grid[index], out var tmxLayerTile);
+
+		    return tmxLayerTile;
+	    }
 
 		/// <summary>
 		/// gets the TmxLayerTile at the given world position
@@ -27,7 +40,7 @@ namespace Nez.Tiled
 		/// </summary>
 		public List<Rectangle> GetCollisionRectangles()
 		{
-			var checkedIndexes = new bool?[Tiles.Length];
+			var checkedIndexes = new bool?[Grid.Length];
 			var rectangles = new List<Rectangle>();
 			var startCol = -1;
 			var index = -1;
@@ -132,10 +145,13 @@ namespace Nez.Tiled
 		/// call this method or update the TmxLayerTile.tileset manually!
 		/// </summary>
 		/// <returns>The tile.</returns>
+		/// <param name="x">The x coordinate.</param>
+		/// <param name="y">The y coordinate.</param>
 		/// <param name="tile">Tile.</param>
-		public TmxLayerTile SetTile(TmxLayerTile tile)
+		public TmxLayerTile SetTile(int x, int y, TmxLayerTile tile)
 		{
-			Tiles[tile.X + tile.Y * Width] = tile;
+			Grid[x + y * Width] = tile.RawGid;
+			Tiles.Add(tile.RawGid, tile);
 			tile.Tileset = Map.GetTilesetForTileGid(tile.Gid);
 
 			return tile;
@@ -146,6 +162,8 @@ namespace Nez.Tiled
 		/// </summary>
 		/// <param name="x">The x coordinate.</param>
 		/// <param name="y">The y coordinate.</param>
-		public void RemoveTile(int x, int y) => Tiles[x + y * Width] = null;
+		public void RemoveTile(int x, int y) {
+			Grid[x + y * Width] = 0;
+		}
     }
 }

--- a/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
@@ -329,20 +329,23 @@ namespace Nez.Tiled
 			if (encoding == "base64")
 			{
 				var decodedStream = new TmxBase64Data(xData);
-				var stream = decodedStream.Data;
-
+				
 				var index = 0;
-				using (var br = new BinaryReader(stream))
-				{
-					for (var j = 0; j < height; j++)
-					{
-						for (var i = 0; i < width; i++)
-						{
-							var gid = br.ReadUInt32();
-							
-							AddTile(layer, map, gid);
-							layer.Grid[index++] = gid;
+				using (var stream = decodedStream.Data) {
+					using (var br = new BinaryReader(stream)) {
+						const int uintSizeInBytes = sizeof(uint);
+						
+						var buffer = new byte[uintSizeInBytes * 1024];
+						int bytesRead;
 
+						while ((bytesRead = br.Read(buffer, 0, buffer.Length)) > 0) {
+							var numberOfUIntValuesRead = bytesRead / uintSizeInBytes;
+							
+							for (var i = 0; i < numberOfUIntValuesRead; i++) {
+								var gid = BitConverter.ToUInt32(buffer, i * uintSizeInBytes);
+								AddTile(layer, map, gid);
+								layer.Grid[index++] = gid;
+							}
 						}
 					}
 				}

--- a/Nez.Portable/Assets/Tiled/TiledTypes/Layer.cs
+++ b/Nez.Portable/Assets/Tiled/TiledTypes/Layer.cs
@@ -27,21 +27,17 @@ namespace Nez.Tiled
 		/// height in tiles for this layer. Always the same as the map height for fixed-size maps.
 		/// </summary>
 		public int Height;
-		public TmxLayerTile[] Tiles;
-
+		public uint[] Grid;
+		public Dictionary<uint, TmxLayerTile> Tiles;
+		
 		/// <summary>
 		/// returns the TmxLayerTile with gid. This is a slow lookup so cache it!
 		/// </summary>
 		/// <param name="gid"></param>
 		/// <returns></returns>
-		public TmxLayerTile GetTileWithGid(int gid)
-		{
-			for (var i = 0; i < Tiles.Length; i++)
-			{
-				if (Tiles[i] != null && Tiles[i].Gid == gid)
-					return Tiles[i];
-			}
-			return null;
+		public TmxLayerTile GetTileWithGid(uint gid) {
+			Tiles.TryGetValue(gid, out var result);
+			return result;
 		}
 	}
 
@@ -52,10 +48,9 @@ namespace Nez.Tiled
 		const uint FLIPPED_DIAGONALLY_FLAG = 0x20000000;
 
 		public TmxTileset Tileset;
+		// GID which still contains the flip flags.
+		public uint RawGid;
 		public int Gid;
-		public int X;
-		public int Y;
-		public Vector2 Position => new Vector2(X, Y);
 		public bool HorizontalFlip;
 		public bool VerticalFlip;
 		public bool DiagonalFlip;
@@ -88,12 +83,10 @@ namespace Nez.Tiled
 				return Tileset.Tiles[_tilesetTileIndex.Value];
 			}
 		}
-
-		public TmxLayerTile(TmxMap map, uint id, int x, int y)
+		
+		public TmxLayerTile(TmxMap map, uint rawGid)
 		{
-			X = x;
-			Y = y;
-			var rawGid = id;
+			RawGid = rawGid;
 
 			// Scan for tile flip bit flags
 			bool flip;

--- a/Nez.Portable/Assets/Tiled/TiledTypes/TmxLayerTileExt.cs
+++ b/Nez.Portable/Assets/Tiled/TiledTypes/TmxLayerTileExt.cs
@@ -91,10 +91,10 @@ namespace Nez.Tiled
 		/// returns the nearest edge to worldPosition
 		/// </summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Edge GetNearestEdge(this TmxLayerTile self, int worldPosition)
+		public static Edge GetNearestEdge(this TmxLayerTile self, int x, int worldPosition)
 		{
 			var tileWidth = self.Tileset.Map.TileWidth;
-			var tileMiddleWorldPosition = self.X * tileWidth + tileWidth / 2;
+			var tileMiddleWorldPosition = x * tileWidth + tileWidth / 2;
 			return worldPosition < tileMiddleWorldPosition ? Edge.Left : Edge.Right;
 		}
 	}


### PR DESCRIPTION
Hello,

I'd like to create large maps in Tiled to e.g. have a town map which also contains the inside of buildings I can enter.
So I need larger maps. When I tried to load a larger map, I realized that it will need a lot of memory.

1. Every tile stores its x/y position. So every tile is unique
https://github.com/prime31/Nez/blob/0c16271e444d41e82e848feb03185bdae6f20e05/Nez.Portable/Assets/Tiled/TiledTypes/Layer.cs#L56-L58
2. CSV layers need lots of memory because of the strings created with Split(',')
https://github.com/prime31/Nez/blob/0c16271e444d41e82e848feb03185bdae6f20e05/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs#L349

I tested the changes I made with a 1000 * 1000 tile (16x16) map with five tile layers. Now each layer needs ~4MB.

**Before**
![large_map_before](https://github.com/prime31/Nez/assets/48615771/55b37a3e-be04-4cbd-91a8-ab500c34d934)
![large_map_layer_before](https://github.com/prime31/Nez/assets/48615771/fa98cb23-30a2-4fba-9335-08154ba38ac3)

**After**
![large_map_after](https://github.com/prime31/Nez/assets/48615771/63c809a0-cafd-47d1-959a-190d6700b5e2)
![large_map_layer_after](https://github.com/prime31/Nez/assets/48615771/e2cfb92b-e05d-4e00-81ad-c536a7145101)


Sadly this is a breaking change because of the removal of the X/Y properties.

E.g. the destructable tilemap-demo in the Samples-repository will have compile errors.
https://github.com/prime31/Nez-Samples/blob/70ad9286a1758a971da723e5dbb30ceb4d4b022a/Nez.Samples/Scenes/Samples/Destructable%20Tilemap/PlayerDashMover.cs#L100

This can be fixed by using:
```csharp
var tileX = _tiledMapRenderer.GetColumnAtWorldPosition(pos.X);
var tileY = _tiledMapRenderer.GetRowAtWorldPosition(pos.Y);
_tiledMapRenderer.CollisionLayer.RemoveTile(tileX, tileY);
```
instead of
```csharp
_tiledMapRenderer.CollisionLayer.RemoveTile(tile.X, tile.Y);
```

Do you think this improvement could benefit other users of the framework or shouldn't it be added because of the breaking change?


Best regards,
stallratte