### PR TITLE
Initialize UserData Property for AsepriteSlice

### DIFF
--- a/Nez.Portable/Assets/Aseprite/AsepriteSlice.cs
+++ b/Nez.Portable/Assets/Aseprite/AsepriteSlice.cs
@@ -39,6 +39,7 @@ namespace Nez.Aseprite
 			HasPivot = hasPivot;
 			Name = name;
 			Keys = new List<AsepriteSliceKey>();
+            UserData = new AsepriteUserData();
 		}
 	}
 }


### PR DESCRIPTION
## Description
This resolves an issue when reading an `AsepriteSlice` that has user data.  Currently the `UserData` property is not initialized in the `AseprietSlice` constructor, which makes it `null` during the read process.

This change ensures the `UserData` property is initialized in the constructor for the `AsperiteSlice` class.