### PR TITLE
SetTile will no longer throw a DuplicateKeyException

### DIFF
--- a/Nez.Portable/Assets/Tiled/Runtime/Layer.Runtime.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/Layer.Runtime.cs
@@ -15,9 +15,7 @@ namespace Nez.Tiled
 	    /// <param name="y">The y coordinate.</param>
 	    public TmxLayerTile GetTile(int x, int y) 
 	    {
-		    Tiles.TryGetValue(Grid[x + y * Width], out var tmxLayerTile);
-
-		    return tmxLayerTile;
+		    return GetTile(x + y * Width);
 	    }
 	    
 	    public TmxLayerTile GetTile(int index) 
@@ -166,11 +164,11 @@ namespace Nez.Tiled
 		/// <returns>The tile.</returns>
 		public TmxLayerTile SetTile(int x, int y, int gid, bool flipHorizontally = false, bool flipVertically = false, bool flipDiagonally = false)
 		{
+			if (gid == 0) return null;
+			
 			uint rawGid = TmxLayerTile.GetRawGid(gid, flipHorizontally, flipVertically, flipDiagonally);
 			
 			Grid[x + y * Width] = rawGid;
-
-			if (rawGid == 0) return null;
 
 			TmxLayerTile tileToSet;
 

--- a/Nez.Portable/Assets/Tiled/Runtime/Layer.Runtime.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/Layer.Runtime.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 
@@ -141,20 +142,47 @@ namespace Nez.Tiled
 		}
 
 		/// <summary>
-		/// sets the tile and updates its tileset. If you change a tiles gid to one in a different Tileset you must
-		/// call this method or update the TmxLayerTile.tileset manually!
+		/// sets the tile.
 		/// </summary>
 		/// <returns>The tile.</returns>
 		/// <param name="x">The x coordinate.</param>
 		/// <param name="y">The y coordinate.</param>
 		/// <param name="tile">Tile.</param>
+		[Obsolete("Please use SetTile with gid instead.")]
 		public TmxLayerTile SetTile(int x, int y, TmxLayerTile tile)
 		{
-			Grid[x + y * Width] = tile.RawGid;
-			Tiles.Add(tile.RawGid, tile);
-			tile.Tileset = Map.GetTilesetForTileGid(tile.Gid);
+			return SetTile(x, y, tile.Gid, tile.HorizontalFlip, tile.VerticalFlip, tile.DiagonalFlip);
+		}
+		
+		/// <summary>
+		/// Sets the tile at position x, y.
+		/// </summary>
+		/// <param name="x">The x coordinate.</param>
+		/// <param name="y">The y coordinate.</param>
+		/// <param name="gid">Global Tile ID (without the flip flags)</param>
+		/// <param name="flipHorizontally">Should the tile be flipped horizontally?</param>
+		/// <param name="flipVertically">Should the tile be flipped vertically?</param>
+		/// <param name="flipDiagonally">Should the tile be flipped diagonally?</param>
+		/// <returns>The tile.</returns>
+		public TmxLayerTile SetTile(int x, int y, int gid, bool flipHorizontally = false, bool flipVertically = false, bool flipDiagonally = false)
+		{
+			uint rawGid = TmxLayerTile.GetRawGid(gid, flipHorizontally, flipVertically, flipDiagonally);
+			
+			Grid[x + y * Width] = rawGid;
 
-			return tile;
+			if (rawGid == 0) return null;
+
+			TmxLayerTile tileToSet;
+
+			if (!Tiles.TryGetValue(rawGid, out var tmxLayerTile)) 
+			{
+				tileToSet = new TmxLayerTile(Map, rawGid);
+				Tiles.Add(rawGid, tileToSet);
+			}
+			else
+				tileToSet = tmxLayerTile;
+			
+			return tileToSet;
 		}
 
 		/// <summary>

--- a/Nez.Portable/Assets/Tiled/TiledTypes/Layer.cs
+++ b/Nez.Portable/Assets/Tiled/TiledTypes/Layer.cs
@@ -47,13 +47,11 @@ namespace Nez.Tiled
 		const uint FLIPPED_VERTICALLY_FLAG = 0x40000000;
 		const uint FLIPPED_DIAGONALLY_FLAG = 0x20000000;
 
-		public TmxTileset Tileset;
-		// GID which still contains the flip flags.
-		public uint RawGid;
-		public int Gid;
-		public bool HorizontalFlip;
-		public bool VerticalFlip;
-		public bool DiagonalFlip;
+		public readonly TmxTileset Tileset;
+		public readonly int Gid;
+		public readonly bool HorizontalFlip;
+		public readonly bool VerticalFlip;
+		public readonly bool DiagonalFlip;
 
 		int? _tilesetTileIndex;
 
@@ -86,8 +84,6 @@ namespace Nez.Tiled
 		
 		public TmxLayerTile(TmxMap map, uint rawGid)
 		{
-			RawGid = rawGid;
-
 			// Scan for tile flip bit flags
 			bool flip;
 			flip = (rawGid & FLIPPED_HORIZONTALLY_FLAG) != 0;
@@ -99,12 +95,39 @@ namespace Nez.Tiled
 			flip = (rawGid & FLIPPED_DIAGONALLY_FLAG) != 0;
 			DiagonalFlip = flip;
 
-			// Zero the bit flags
-			rawGid &= ~(FLIPPED_HORIZONTALLY_FLAG | FLIPPED_VERTICALLY_FLAG | FLIPPED_DIAGONALLY_FLAG);
-
-			// Save GID remainder to int
-			Gid = (int)rawGid;
+			Gid = ClearFlipFlags(rawGid);
 			Tileset = map.GetTilesetForTileGid(Gid);
+		}
+
+		/// <summary>
+		/// Applies the given flip flags to the given Global Tile ID.
+		/// </summary>
+		/// <param name="gid">Global Tile ID (without the flip flags)</param>
+		/// <param name="flipHorizontally">Horizontally flipped?</param>
+		/// <param name="flipVertically">Vertically flipped?</param>
+		/// <param name="flipDiagonally">Diagonally flipped?</param>
+		/// <returns>Global Tile ID (with the flip flags)</returns>
+		public static uint GetRawGid(int gid, bool flipHorizontally, bool flipVertically, bool flipDiagonally) 
+		{
+			if (gid == 0) return 0;
+
+			var rawGid = (uint)gid;
+
+			if (flipHorizontally) rawGid |= FLIPPED_HORIZONTALLY_FLAG;
+			if (flipVertically) rawGid |= FLIPPED_VERTICALLY_FLAG;
+			if (flipDiagonally) rawGid |= FLIPPED_DIAGONALLY_FLAG;
+
+			return rawGid;
+		}
+		
+		/// <summary>
+		/// Clears flip flags from the given Global Tile Id.
+		/// </summary>
+		/// <param name="rawGid">Global Tile ID (with the flip flags)</param>
+		/// <returns>Global Tile ID (without the flip flags)</returns>
+		public static int ClearFlipFlags(uint rawGid)
+		{
+			return (int)(rawGid & ~(FLIPPED_HORIZONTALLY_FLAG | FLIPPED_VERTICALLY_FLAG | FLIPPED_DIAGONALLY_FLAG));
 		}
 	}
 


### PR DESCRIPTION
Optimo found a bug which was caused by the changes a made to the datastructure:

When trying to set a tile which already exists, a DuplicateKeyException is thrown. This is fixed now.

Because of the comment on the method:
> sets the tile and updates its tileset. If you change a tiles gid to one in a different Tileset you must call this method or update the TmxLayerTile.tileset manually!

I realized that there were two supported ways to replace a tile before my change:
1. Nez.Tiled.TmxLayer.SetTile
2. Get the reference of a TmxLayerTile and directly change Gid and manually update the Tileset if the gid is in a different tileset

The second way is now no longer possible. Using the second way will lead to unwanted behaviour.

Directly changing the TmxLayerTile also made it possible to change the flip flags. I think that's an edge case but I don't want to strip down the functionality for the users of the framework.

To avoid unwanted behaviour, I made the Gid and Flags readonly to force the use of the SetTile-method.
To make it possible again to also change the flags, I added an overloaded SetTile-Method. 

Please let me know if these changes are ok.


Best regards,
stallratte