### PR TITLE
Allow LoadTmxMap to use NezContentManager for loading textures.

### DIFF
--- a/Nez.Portable/Assets/NezContentManager.cs
+++ b/Nez.Portable/Assets/NezContentManager.cs
@@ -136,7 +136,7 @@ namespace Nez.Systems
 					return map;
 			}
 
-			var tiledMap = new TmxMap().LoadTmxMap(name);
+			var tiledMap = new TmxMap().LoadTmxMap(name, this);
 
 			LoadedAssets[name] = tiledMap;
 			DisposableAssets.Add(tiledMap);


### PR DESCRIPTION
I use this in my game because I do some preprocessing of the TMX maps and textures upfront in the content pipeline

However it feels like it's a general useful addition since at the very least it optimises the case where you have several maps/tiles loaded which share a tileset image as the `ContentManager` will only load it once.

I've opted to make this optional outside of `NezContentManager.LoadTiledMap` so as to avoid introducing a breaking change.