### PR TITLE
Added support for FNA.Core

### DIFF
--- a/Nez.FNA.Core.sln
+++ b/Nez.FNA.Core.sln
@@ -1,0 +1,81 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nez.FNA", "Nez.Portable\Nez.FNA.Core.csproj", "{60B7197D-D0D5-405C-90A2-A56903E9B039}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nez.FNA.FarseerPhysics", "Nez.FarseerPhysics\Nez.FNA.Core.FarseerPhysics.csproj", "{CB893B1D-CE04-4492-B957-31CE0DCA6C15}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nez.FNA.ImGui", "Nez.ImGui\Nez.FNA.Core.ImGui.csproj", "{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FNA", "..\FNA\FNA.Core.csproj", "{35253CE1-C864-4CD3-8249-4D1319748E8F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nez.FNA.Persistence", "Nez.Persistence\Nez.FNA.Core.Persistence.csproj", "{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}"
+EndProject
+
+Global
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|x86.Build.0 = Debug|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|x86.ActiveCfg = Release|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|x86.Build.0 = Release|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Debug|x64.Build.0 = Debug|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|x64.ActiveCfg = Release|Any CPU
+		{60B7197D-D0D5-405C-90A2-A56903E9B039}.Release|x64.Build.0 = Release|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|x86.Build.0 = Debug|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|x86.ActiveCfg = Release|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|x86.Build.0 = Release|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Debug|x64.Build.0 = Debug|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|x64.ActiveCfg = Release|Any CPU
+		{CB893B1D-CE04-4492-B957-31CE0DCA6C15}.Release|x64.Build.0 = Release|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|x86.Build.0 = Debug|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|x86.ActiveCfg = Release|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|x86.Build.0 = Release|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Debug|x64.Build.0 = Debug|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|x64.ActiveCfg = Release|Any CPU
+		{2555137D-E6E3-4897-BFF4-7F6DC3DC2BC4}.Release|x64.Build.0 = Release|Any CPU
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|x86.ActiveCfg = Debug|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|x86.Build.0 = Debug|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|x86.ActiveCfg = Release|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|x86.Build.0 = Release|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|x64.ActiveCfg = Debug|x64
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|x64.Build.0 = Debug|x64
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|x64.ActiveCfg = Release|x64
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|x64.Build.0 = Release|x64
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|Any CPU.Build.0 = Release|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|x86.Build.0 = Debug|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|x86.ActiveCfg = Release|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|x86.Build.0 = Release|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|iPhone.Build.0 = Release|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{f8c8a3ad-84fe-4bda-952f-223b1b3c6bcd}.Debug|iPhone.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+EndGlobal

--- a/Nez.FarseerPhysics/Nez.FNA.Core.FarseerPhysics.csproj
+++ b/Nez.FarseerPhysics/Nez.FNA.Core.FarseerPhysics.csproj
@@ -1,0 +1,40 @@
+<Project>	
+	<PropertyGroup>
+		<BaseIntermediateOutputPath>obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+	</PropertyGroup>
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+	
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<OutputType>Library</OutputType>
+		<RootNamespace>Nez.Farseer</RootNamespace>
+		<AssemblyName>Nez.FarseerPhysics</AssemblyName>
+		<TargetFramework>net7.0</TargetFramework>
+		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<OutputPath>bin\$(Configuration)\FNA</OutputPath>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DefineConstants>TRACE;DEBUG;FNA</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DefineConstants>FNA</DefineConstants>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\FNA\FNA.Core.csproj">
+		</ProjectReference>
+		<ProjectReference Include="..\Nez.Portable\Nez.FNA.Core.csproj">
+		</ProjectReference>
+	</ItemGroup>
+
+	<PropertyGroup>
+		<DefaultItemExcludes>$(DefaultItemExcludes);Properties\*.*</DefaultItemExcludes>
+	</PropertyGroup>
+	
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+</Project>

--- a/Nez.ImGui/Nez.FNA.Core.ImGui.csproj
+++ b/Nez.ImGui/Nez.FNA.Core.ImGui.csproj
@@ -1,0 +1,70 @@
+<Project>	
+	<PropertyGroup>
+		<BaseIntermediateOutputPath>obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+	</PropertyGroup>
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+	
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<OutputType>Library</OutputType>
+		<RootNamespace>Nez.ImGuiTools</RootNamespace>
+		<AssemblyName>Nez.ImGui</AssemblyName>
+        <TargetFramework>net7.0</TargetFramework>
+		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<OutputPath>bin\$(Configuration)\FNA</OutputPath>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DefineConstants>TRACE;DEBUG;FNA</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DefineConstants>FNA</DefineConstants>
+	</PropertyGroup>
+
+
+	<ItemGroup>
+		<ProjectReference Include="../../FNA/FNA.Core.csproj" />
+		<ProjectReference Include="../Nez.Portable/Nez.FNA.Core.csproj" />
+		<ProjectReference Include="../Nez.Persistence/Nez.FNA.Core.Persistence.csproj" />
+	</ItemGroup>
+
+	<PropertyGroup>
+		<IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
+		<IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+	</PropertyGroup>
+
+
+	<!-- Copy ImGui native code to output -->
+	<PropertyGroup>
+		<ImGuiRuntimes>$(NuGetPackageRoot)\imgui.net\**\runtimes\</ImGuiRuntimes>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Content Include="$(ImGuiRuntimes)win-x86\native\*.dll" Condition="'$(OS)' == 'Windows_NT' AND '$(Platform)' != 'x64'">
+			<Link>%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="$(ImGuiRuntimes)win-x64\native\*.dll" Condition="'$(OS)' == 'Windows_NT' AND '$(Platform)' != 'x86'">
+			<Link>%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="$(ImGuiRuntimes)osx-x64\native\*.dylib" Condition="'$(OS)' != 'Windows_NT' AND $(IsOSX) == 'true'">
+			<Link>libcimgui.dylib</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include=".$(ImGuiRuntimes)linux-x64\native\*.so" Condition="'$(OS)' != 'Windows_NT' AND $(IsLinux) == 'true'">
+			<Link>%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="ImGui.NET" Version="1.89.5" />
+	</ItemGroup>
+	
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+</Project>

--- a/Nez.Persistence/Nez.FNA.Core.Persistence.csproj
+++ b/Nez.Persistence/Nez.FNA.Core.Persistence.csproj
@@ -1,0 +1,33 @@
+<Project>	
+	<PropertyGroup>
+		<BaseIntermediateOutputPath>obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+	</PropertyGroup>
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+	
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<OutputType>Library</OutputType>
+		<RootNamespace>Nez.Persistence</RootNamespace>
+		<AssemblyName>Nez.Persistence</AssemblyName>
+		<TargetFramework>net7.0</TargetFramework>
+		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<OutputPath>bin\$(Configuration)\FNA</OutputPath>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DefineConstants>TRACE;DEBUG;FNA</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DefineConstants>FNA</DefineConstants>
+	</PropertyGroup>
+
+    <PropertyGroup>
+        <DefaultItemExcludes>$(DefaultItemExcludes);Tests\**\*.*</DefaultItemExcludes>
+    </PropertyGroup>
+
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+</Project>

--- a/Nez.Portable/Nez.FNA.Core.csproj
+++ b/Nez.Portable/Nez.FNA.Core.csproj
@@ -1,0 +1,49 @@
+<Project>	
+	<PropertyGroup>
+		<BaseIntermediateOutputPath>obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+	</PropertyGroup>
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<OutputType>Library</OutputType>
+		<RootNamespace>Nez</RootNamespace>
+		<AssemblyName>Nez</AssemblyName>
+		<TargetFramework>net7.0</TargetFramework>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<IntermediateOutputPath>obj\Nez.FNA\$(Configuration)</IntermediateOutputPath>
+		<OutputPath>bin\$(Configuration)\FNA</OutputPath>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DefineConstants>TRACE;DEBUG;FNA;FNA_GCHANDLE</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DefineConstants>FNA;FNA_GCHANDLE</DefineConstants>
+	</PropertyGroup>
+
+    <ItemGroup>
+      	<Compile Remove="Graphics\SVG\Shapes\Paths\SvgPathBuilder.cs" />
+    </ItemGroup>
+
+	<ItemGroup>
+		<EmbeddedResource Include="Content\NezDefaultBMFont.xnb">
+			<Link>Content\NezDefaultBMFont.xnb</Link>
+		</EmbeddedResource>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\FNA\FNA.Core.csproj">
+		</ProjectReference>
+	</ItemGroup>
+	
+	<ItemGroup>
+		<PackageReference Include="System.Drawing.Common" Version="8.0.5" />
+	</ItemGroup>
+	
+	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+</Project>


### PR DESCRIPTION
FNA has a set of `.Core.csproj` projects that allow it to run with dotnet core 7 (and in my case 8). This doesn't work with Nez because Nez depends on either `net471` or `netstandard2.0`. Both of which I could not get to work with dotnet core 8 (please tell me if there is a way to make this work).

This PR adds a `.FNA.Core` version of:
- `Nez.FarseerPhysics`
- `Nez.ImGui`
- `Nez.Persistence`
- `Nez.Portable`

Additionally I have added a define `FNA_GCHANDLE` to nez portable as a workaround for #804. This made Nez work with an FNA version younger than 6 months old, which is what I imagine most dotnet core people would use.