### PR TITLE
fixes modulus error when UpdateInterval is set to zero - EntityList.cs

### DIFF
--- a/Nez.Portable/ECS/InternalUtils/EntityList.cs
+++ b/Nez.Portable/ECS/InternalUtils/EntityList.cs
@@ -161,6 +161,10 @@ namespace Nez
 			for (var i = 0; i < _entities.Length; i++)
 			{
 				var entity = _entities.Buffer[i];
+				
+				if (entity.UpdateInterval == 0)
+					continue;
+
 				if (entity.Enabled && (entity.UpdateInterval == 1 || Time.FrameCount % entity.UpdateInterval == 0))
 					entity.Update();
 			}


### PR DESCRIPTION
it will skip in the case UpdateInterval is set to zero, where it would normally error with the modulus operation on the next line. this patch does double-duty,  when UpdateInterval is set to zero it allows effectively pausing of Entity updates.