### PR TITLE
ChangeState non-generic method - TypeStateMachine.cs

### DIFF
--- a/Nez.Portable/AI/FSM/StateMachine.cs
+++ b/Nez.Portable/AI/FSM/StateMachine.cs
@@ -98,5 +98,16 @@ namespace Nez.AI.FSM
 		{
 			return ChangeState(typeof(R)) as R;
 		}
+
+		/// <summary>
+		/// changes to the previous state if one exists
+		/// </summary>
+		public State<T> ChangeToPreviousState()
+		{
+			if (PreviousState == null)
+				return _currentState as State<T>;
+
+			return ChangeState(PreviousState.GetType());
+		}
 	}
 }

--- a/Nez.Portable/AI/FSM/StateMachine.cs
+++ b/Nez.Portable/AI/FSM/StateMachine.cs
@@ -62,16 +62,14 @@ namespace Nez.AI.FSM
 			return (R)_states[type];
 		}
 
-
 		/// <summary>
 		/// changes the current state
 		/// </summary>
-		public R ChangeState<R>() where R : State<T>
+		public State<T> ChangeState(Type newType)
 		{
 			// avoid changing to the same state
-			var newType = typeof(R);
 			if (_currentState.GetType() == newType)
-				return _currentState as R;
+				return _currentState as State<T>;
 
 			// only call end if we have a currentState
 			if (_currentState != null)
@@ -90,7 +88,15 @@ namespace Nez.AI.FSM
 			if (OnStateChanged != null)
 				OnStateChanged();
 
-			return _currentState as R;
+			return _currentState as State<T>;
+		}
+
+		/// <summary>
+		/// changes the current state
+		/// </summary>
+		public R ChangeState<R>() where R : State<T>
+		{
+			return ChangeState(typeof(R)) as R;
 		}
 	}
 }


### PR DESCRIPTION
I wanted to be able to use a runtime-resolved type for the generic part of of ChangeState<R>. The messy way is with some reflection and binding. Instead here I created a new method with the same name, but non-generic. You simply pass in the Type. 

I've redressed the existing method to call thru to the new method.

Also added a ChangeToPreviousState() method that does what it says by calling the new method with the PreviousType as its argument. As long as it's non-null type it will work, in any case returning the _currentState as State<T>.