### PR TITLE
Use parameter in bitmap font extension method

### DIFF
--- a/Nez.Portable/Assets/BitmapFonts/BatcherBitmapFontExt.cs
+++ b/Nez.Portable/Assets/BitmapFonts/BatcherBitmapFontExt.cs
@@ -131,7 +131,7 @@ namespace Nez.BitmapFonts
 			foreach (var glyph in glyphs)
 			{
 				var characterOrigin = origin - glyph.Position;
-				Graphics.Instance.Batcher.Draw(glyph.Texture, position, glyph.Character.Bounds, color, rotation,
+				batcher.Draw(glyph.Texture, position, glyph.Character.Bounds, color, rotation,
 					characterOrigin, scale, SpriteEffects.None, layerDepth);
 			}
 		}


### PR DESCRIPTION
Was skimming through code the other night and this caught my eye. Despite that in probably nearly all cases the instance referenced would likely be the same, it seemed like the right thing to do :)