### PR TITLE
Updated sprite renderer render function to account for flipX and flipY when rendering

### DIFF
--- a/Nez.Portable/ECS/Components/Renderables/Sprites/SpriteRenderer.cs
+++ b/Nez.Portable/ECS/Components/Renderables/Sprites/SpriteRenderer.cs
@@ -184,10 +184,13 @@ namespace Nez.Sprites
 			Color = originalColor;
 			_layerDepth = originalLayerDepth;
 		}
-
+		
 		public override void Render(Batcher batcher, Camera camera)
 		{
-			batcher.Draw(Sprite, Entity.Transform.Position + LocalOffset, Color,
+			Vector2 isFlippedVector = new Vector2(FlipX ? -1 : 1, FlipY ? -1 : 1);
+			Vector2 adjustedLocalOffset = LocalOffset * isFlippedVector;
+
+			batcher.Draw(Sprite, Entity.Transform.Position + adjustedLocalOffset, Color,
 				Entity.Transform.Rotation, Origin, Entity.Transform.Scale, SpriteEffects, _layerDepth);
 		}
 	}

--- a/Nez.Portable/ECS/Components/Renderables/Sprites/SpriteRenderer.cs
+++ b/Nez.Portable/ECS/Components/Renderables/Sprites/SpriteRenderer.cs
@@ -184,7 +184,7 @@ namespace Nez.Sprites
 			Color = originalColor;
 			_layerDepth = originalLayerDepth;
 		}
-		
+
 		public override void Render(Batcher batcher, Camera camera)
 		{
 			Vector2 isFlippedVector = new Vector2(FlipX ? -1 : 1, FlipY ? -1 : 1);


### PR DESCRIPTION
Currently, when you have a sprite renderer with a non-zero localOffset, when the sprite is flipped it does not adjust that offset, causing a flipped sprite to be misaligned. 

This PR adds this adjustment so that when the image is flipped we multiply that part of the offset by -1.