### PR TITLE
Adding support for Tiled classes

### DIFF
--- a/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
@@ -194,7 +194,6 @@ namespace Nez.Tiled
 
 							dict.Add(pname, pval);
 						}
-
 					}
 				}
 				else
@@ -205,7 +204,6 @@ namespace Nez.Tiled
 
 					dict.Add(pname, pval);
 				}
-
 			}
 			return dict;
 		}

--- a/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
@@ -179,12 +179,33 @@ namespace Nez.Tiled
 			foreach (var p in xmlProp.Elements("property"))
 			{
 				var pname = p.Attribute("name").Value;
+				var isClass = p.Attribute("type") != null && p.Attribute("type").Value == "class";
+				XAttribute valueAttr;
+				var pval = string.Empty;
+				if (isClass)
+				{
+					// Loop through sub elements and pull name/value for dict
+					foreach (var subP in p.Elements("properties").DescendantNodes())
+					{
+						if (subP is XElement element)
+						{
+							pname = element.Attribute("name")?.Value;
+							pval = element.Attribute("value")?.Value ?? element.Value;
 
-				// Fallback to element value if no "value"
-				var valueAttr = p.Attribute("value");
-				var pval = valueAttr?.Value ?? p.Value;
+							dict.Add(pname, pval);
+						}
 
-				dict.Add(pname, pval);
+					}
+				}
+				else
+				{
+					// Fallback to element value if no "value"
+					valueAttr = p.Attribute("value");
+					pval = valueAttr?.Value ?? p.Value;
+
+					dict.Add(pname, pval);
+				}
+
 			}
 			return dict;
 		}


### PR DESCRIPTION
## Description
This PR addresses adding adding support for sub elements in the tiled `ParsePropertyDict` method by adding support for classes. What are tiled classes? https://doc.mapeditor.org/en/stable/manual/custom-properties/#custom-classes - they are used to add a set of properties at once, but don't work out of the box in Nez due to their sub-property nature.

## Testing steps
Ensure your local version of Tiled supports classes (introduced in Tiled 1.9).

- Create a new Tiled project
- Hit control+shift+p to open the action search widget (likely command+shift+p on mac?)
- Search `Custom types editor`
- Add a class
- Give the class some properties
- Create a new tmx map and create an object, giving it the class as a property. Save this and load it into Nez.

The specific part of the TMX file we care about looks something like this (using mine as reference):
```
<objectgroup id="9" name="EnemySpawn">
  <object id="8" x="32" y="224" width="112" height="32">
   <properties>
    <property name="Spawns" type="class" propertytype="EnemySpawn">
     <properties>
      <property name="Enemy1" propertytype="Enemies" value="Misfit"/>
      <property name="Enemy1Odds" type="float" value="0.050000000000000044"/>
      <property name="Enemy2" propertytype="Enemies" value="Goblin"/>
      <property name="Enemy2Odds" type="float" value="0.08"/>
      <property name="LevelMax" type="int" value="1"/>
      <property name="LevelMin" type="int" value="3"/>
      <property name="MaxCount" type="int" value="1"/>
      <property name="MinCount" type="int" value="5"/>
     </properties>
    </property>
   </properties>
  </object>
 </objectgroup>
```

In Nez, you can access it the same as you would normally by looping through objects in an object group:

```
foreach (var enemySpawn in _tmxMap.GetObjectGroup("EnemySpawn")?.Objects ?? [])
```

Due note, the original behaviour was kept as-was in the event that you're not dealing with classes.