### PR TITLE
Update Pool.cs documentation

### DIFF
--- a/Nez.Portable/Utils/Collections/Pool.cs
+++ b/Nez.Portable/Utils/Collections/Pool.cs
@@ -73,7 +73,7 @@ namespace Nez
 
 
 	/// <summary>
-	/// Objects implementing this interface will have {@link #reset()} called when passed to {@link #push(Object)}
+	/// Objects implementing this interface will have <see cref="Reset"/> called when passed to <see cref="Pool.Free"/>
 	/// </summary>
 	public interface IPoolable
 	{


### PR DESCRIPTION
C# XML documentation does not seem to support `{@link #...}` style. Also this one was referencing `push` when `Pool.Free` was meant.