### PR TITLE
FNA.Core: net7.0 -> net8.0

### DIFF
--- a/Nez.FarseerPhysics/Nez.FNA.Core.FarseerPhysics.csproj
+++ b/Nez.FarseerPhysics/Nez.FNA.Core.FarseerPhysics.csproj
@@ -10,7 +10,7 @@
 		<OutputType>Library</OutputType>
 		<RootNamespace>Nez.Farseer</RootNamespace>
 		<AssemblyName>Nez.FarseerPhysics</AssemblyName>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/Nez.ImGui/Nez.FNA.Core.ImGui.csproj
+++ b/Nez.ImGui/Nez.FNA.Core.ImGui.csproj
@@ -10,7 +10,7 @@
 		<OutputType>Library</OutputType>
 		<RootNamespace>Nez.ImGuiTools</RootNamespace>
 		<AssemblyName>Nez.ImGui</AssemblyName>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/Nez.Persistence/Nez.FNA.Core.Persistence.csproj
+++ b/Nez.Persistence/Nez.FNA.Core.Persistence.csproj
@@ -10,7 +10,7 @@
 		<OutputType>Library</OutputType>
 		<RootNamespace>Nez.Persistence</RootNamespace>
 		<AssemblyName>Nez.Persistence</AssemblyName>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/Nez.Portable/Nez.FNA.Core.csproj
+++ b/Nez.Portable/Nez.FNA.Core.csproj
@@ -10,8 +10,9 @@
 		<OutputType>Library</OutputType>
 		<RootNamespace>Nez</RootNamespace>
 		<AssemblyName>Nez</AssemblyName>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<IntermediateOutputPath>obj\Nez.FNA\$(Configuration)</IntermediateOutputPath>


### PR DESCRIPTION
Hello,

the current version of FNA.Core supports net8.0: https://github.com/FNA-XNA/FNA/blob/master/FNA.Core.csproj#L3
So I updated the TargetFramework version.

This would solve this issue: https://github.com/prime31/Nez/issues/840


Best regards,
stallratte