### PR TITLE
Batcher: Removed half pixel offset calculation.

### DIFF
--- a/Nez.Portable/Core.cs
+++ b/Nez.Portable/Core.cs
@@ -149,7 +149,7 @@ namespace Nez
 				SynchronizeWithVerticalRetrace = true,
 #if MONOGAME_38
 				HardwareModeSwitch = hardwareModeSwitch,
-				PreferHalfPixelOffset = true
+				PreferHalfPixelOffset = false
 #endif
 			};
 			graphicsManager.DeviceReset += OnGraphicsDeviceReset;

--- a/Nez.Portable/Graphics/Batcher/Batcher.cs
+++ b/Nez.Portable/Graphics/Batcher/Batcher.cs
@@ -79,10 +79,7 @@ namespace Nez
 
 
 		#region static variables and constants
-
-		/// if true, the older FNA half-pixel offset will be used when creating the ortho matrix. Autoset to true for FNA.
-		public static bool UseFnaHalfPixelMatrix = false;
-
+		
 		const int MAX_SPRITES = 2048;
 		const int MAX_VERTICES = MAX_SPRITES * 4;
 		const int MAX_INDICES = MAX_SPRITES * 6;
@@ -93,10 +90,6 @@ namespace Nez
 		static readonly short[] _indexData = GenerateIndexArray();
 
 		#endregion
-
-		#if FNA
-		static Batcher() => UseFnaHalfPixelMatrix = true;
-		#endif
 
 		public Batcher(GraphicsDevice graphicsDevice)
 		{
@@ -1068,19 +1061,10 @@ namespace Nez
 			var viewport = GraphicsDevice.Viewport;
 
 			// inlined CreateOrthographicOffCenter
-			if (UseFnaHalfPixelMatrix)
-			{
-				_projectionMatrix.M11 = (float)(2.0 / (double)(viewport.Width / 2 * 2 - 1));
-				_projectionMatrix.M22 = (float)(-2.0 / (double)(viewport.Height / 2 * 2 - 1));
-			}
-			else
-			{
-				_projectionMatrix.M11 = (float)(2.0 / (double)viewport.Width);
-				_projectionMatrix.M22 = (float)(-2.0 / (double)viewport.Height);
-			}
-
-			_projectionMatrix.M41 = -1 - 0.5f * _projectionMatrix.M11;
-			_projectionMatrix.M42 = 1 - 0.5f * _projectionMatrix.M22;
+			_projectionMatrix.M11 = (float)(2.0 / (double)viewport.Width);
+			_projectionMatrix.M22 = (float)(-2.0 / (double)viewport.Height);
+			_projectionMatrix.M41 = -1;
+			_projectionMatrix.M42 = 1;
 
 			Matrix.Multiply(ref _transformMatrix, ref _projectionMatrix, out _matrixTransformMatrix);
 			_spriteEffect.SetMatrixTransform(ref _matrixTransformMatrix);

--- a/Nez.Portable/Graphics/Batcher/BatcherDrawingExt.cs
+++ b/Nez.Portable/Graphics/Batcher/BatcherDrawingExt.cs
@@ -125,7 +125,7 @@ namespace Nez
 		                                 float thickness)
 		{
 			batcher.Draw(Graphics.Instance.PixelTexture, start, Graphics.Instance.PixelTexture.SourceRect, color,
-				radians, new Vector2(0f, 0.5f), new Vector2(length, thickness), SpriteEffects.None, 0);
+				radians, new Vector2(0f, 0f), new Vector2(length, thickness), SpriteEffects.None, 0);
 		}
 
 


### PR DESCRIPTION
Hello,

when switching from Monogame to FNA, I experienced some kind of texture bleeding:
![one_pixel_line](https://github.com/user-attachments/assets/12ee40ea-f770-47a5-b069-5ee78c6987fb)

**FNA**

I compared the NEZ Batcher with the FNA Batcher.
(Kinda hard to read because of pointer arithmetic)

https://github.com/FNA-XNA/FNA/blob/master/src/Graphics/SpriteBatch.cs#L1436-L1457

```
// transformMatrix = Matrix.Identity
// notice the memory layout
M11	dstPtr[0] = (tfWidth * 1) - 0;			// tfWidth => (float) (2.0 / (double) viewport.Width)
M21	dstPtr[1] = (tfWidth * 0) - 0;
M31	dstPtr[2] = (tfWidth * 0) - 0;
M41	dstPtr[3] = (tfWidth * 0) - 1;			// -1
M12	dstPtr[4] = (tfHeight * 0) + 0;
M22	dstPtr[5] = (tfHeight * 1) + 0;			// tfHeight = (float) (-2.0 / (double) viewport.Height)
M32	dstPtr[6] = (tfHeight * 0) + 0;
M42	dstPtr[7] = (tfHeight * 0) + 1;			// 1
M13	dstPtr[8] = 0;
M23	dstPtr[9] = 0;
M33	dstPtr[10] = 0;
M43	dstPtr[11] = 0;
M14	dstPtr[12] = 0;
M24	dstPtr[13] = 0;
M34	dstPtr[14] = 0;
M44	dstPtr[15] = 1;							// 1
```

_Key takeaway:_
M11 = (float)(2.0 / (double)viewport.Width)
M22 = (float)(-2.0 / (double)viewport.Height)
M41 = -1
M42 = 1

So no half pixel offset is calculated in the SpriteBatcher of FNA.

This is also mentioned here: https://fna-xna.github.io/docs/2a%3A-Building-XNA-Games-with-FNA/#2a-about-effect-support

> We do not attempt to undo half-pixel offsets applied by the game's shaders. If you don't know what this is, don't worry. If you do know what this is and have applied them in your engine, simply remove them from the FNA version of your game and it should visually match D3D without any problems.

(I initially got confused because of https://github.com/FNA-XNA/FNA/blob/master/src/Graphics/Effect/StockEffects/SpriteEffect.cs#L71-L74
But SpriteEffect is not used anywhere and is an internal class. So the offset calculation is never applied anywhere.)


**Monogame**

I also checked the SpriteBatcher of Monogame. 
It also does not apply an offset by default:
- https://github.com/MonoGame/MonoGame/blob/develop/MonoGame.Framework/Graphics/SpriteBatch.cs#L100
- https://github.com/MonoGame/MonoGame/blob/develop/MonoGame.Framework/Graphics/Effect/SpriteEffect.cs#L71-L85

But it does if 'UseHalfPixelOffset' is set to true. So they still support this feature (for OpenGL):
https://docs.monogame.net/articles/migration/migrate_xna.html

For DirectX the flag will be set to false: https://github.com/MonoGame/MonoGame/blob/develop/MonoGame.Framework/Graphics/GraphicsDevice.cs#L317-L320

_Key takeaways from the article:_
1. This flag is set to false by default to encourage users to use the modern style of pixel addressing.
2. SpriteBatch rendering is not affected by the flag.

**Changes**

Completely removed the half pixel offset calculation in the Batcher.
This benefits FNA and Monogame. For both frameworks this calculation should not be used.
The problems are more visible when using FNA but M41/M42 is also a little bit off for Monogame.

Set the Monogame-specific 'UseHalfPixelOffset'-Flag in Core to false. I do not think many users will need this feature. And having it set to true by default will do more harm than good. That's also the reason why this flag is set to false by default in monogame.

I am aware that legacy XNA games in Monogame will now have the half pixel offset problem. But to fix this, it would be necessary to check for more conditions aside from 'UseHalfPixelOffset'. 
And I don't think adding this legacy feature is worth the time.

I did test this change with FNA and Monogame (OpenGL only) and in both cases I didn't see any texture bleeding.

Best regards,
stallratte