### PR TITLE
Aseprite convenience method should include background layer

### DIFF
--- a/Nez.Portable/Assets/Aseprite/AsepriteFile.cs
+++ b/Nez.Portable/Assets/Aseprite/AsepriteFile.cs
@@ -214,7 +214,7 @@ namespace Nez.Aseprite
 			// frameNumber is base-one in the aseprite app,
 			// but Frames array is base-zero, so we subtract 1
 			AsepriteFrame frame = Frames[frameNumber - 1];
-			Color[] pixels = frame.FlattenFrame();
+			Color[] pixels = frame.FlattenFrame(true, true);
 			Texture2D texture = new Texture2D(Core.GraphicsDevice, frame.Width, frame.Height);
 			texture.SetData<Color>(pixels);
 			return texture;


### PR DESCRIPTION
the GetTextureFromFrameNumber method was supposed to have this when we originally came up with it. corrected now by including the background layer; the resulting flattened texture is wholly complete - everything visible is included, as intended.