### PR TITLE
Access _isNewSceneLoaded in 3rd-party SceneTransition subclasses

### DIFF
--- a/Nez.Portable/Graphics/Transitions/SceneTransition.cs
+++ b/Nez.Portable/Graphics/Transitions/SceneTransition.cs
@@ -82,7 +82,7 @@ namespace Nez
 		/// use this for two part transitions. For example, a fade would fade to black first then when _isNewSceneLoaded becomes true it would
 		/// fade in. For in-Scene transitions _isNewSceneLoaded should be set to true at the midpoint just as if a new Scene was loaded.
 		/// </summary>
-		internal bool _isNewSceneLoaded;
+		protected internal bool _isNewSceneLoaded;
 
 
 		protected SceneTransition(bool wantsPreviousSceneRender = true) : this(null, wantsPreviousSceneRender)


### PR DESCRIPTION
_isNewSceneLoaded was 'internal'. This would limit it to only be accessible to SceneTransition subclasses inside the Nez assembly. We make it 'protected' so derived subclasses in one's own project assembly can access the field.