### PR TITLE
Make Core.SceneTransition a public property

### DIFF
--- a/Nez.Portable/Core.cs
+++ b/Nez.Portable/Core.cs
@@ -94,6 +94,7 @@ namespace Nez
 		Scene _scene;
 		Scene _nextScene;
 		internal SceneTransition _sceneTransition;
+		public SceneTransition SceneTransition => _sceneTransition;
 
 		/// <summary>
 		/// used to coalesce GraphicsDeviceReset events


### PR DESCRIPTION
Simply adds a public prop (getter) for the internal private field.