### PR TITLE
ImGuiManager - split-up Unload into two methods

### DIFF
--- a/Nez.ImGui/Core/ImGuiManager.Impl.cs
+++ b/Nez.ImGui/Core/ImGuiManager.Impl.cs
@@ -60,31 +60,36 @@ namespace Nez.ImGuiTools
 		{
 			// when the Scene changes we need to rewire ourselves up as the IFinalRenderDelegate in the new Scene
 			// if we were previously enabled and do some cleanup
-			Unload();
+			ResetRenderTarget();
 			_sceneGraphWindow.OnSceneChanged();
+
+			ClearLists();
 
 			if (Enabled)
 				OnEnabled();
 		}
 
-		void Unload()
-		{
-			_drawCommands.Clear();
-			_entityInspectors.Clear();
+		void ResetRenderTarget()
+        {
+            if (_renderTargetId != IntPtr.Zero)
+            {
+                _renderer.UnbindTexture(_renderTargetId);
+                _renderTargetId = IntPtr.Zero;
+            }
 
-			if (_renderTargetId != IntPtr.Zero)
-			{
-				_renderer.UnbindTexture(_renderTargetId);
-				_renderTargetId = IntPtr.Zero;
-			}
+            _lastRenderTarget = null;
+        }
 
-			_lastRenderTarget = null;
-		}
+        void ClearLists()
+        {
+            _drawCommands.Clear();
+            _entityInspectors.Clear();
+        }
 
-		/// <summary>
-		/// draws the game window and deals with overriding Nez.Input when appropriate
-		/// </summary>
-		void DrawGameWindow()
+        /// <summary>
+        /// draws the game window and deals with overriding Nez.Input when appropriate
+        /// </summary>
+        void DrawGameWindow()
 		{
 			if (_lastRenderTarget == null)
 				return;
@@ -279,7 +284,7 @@ namespace Nez.ImGuiTools
 
 		public override void OnDisabled()
 		{
-			Unload();
+			ResetRenderTarget();
 			if (Core.Scene != null)
 				Core.Scene.FinalRenderDelegate = null;
 		}

--- a/Nez.ImGui/Core/ImGuiManager.Impl.cs
+++ b/Nez.ImGui/Core/ImGuiManager.Impl.cs
@@ -70,26 +70,26 @@ namespace Nez.ImGuiTools
 		}
 
 		void ResetRenderTarget()
-        {
-            if (_renderTargetId != IntPtr.Zero)
-            {
-                _renderer.UnbindTexture(_renderTargetId);
-                _renderTargetId = IntPtr.Zero;
-            }
+		{
+			if (_renderTargetId != IntPtr.Zero)
+			{
+				_renderer.UnbindTexture(_renderTargetId);
+				_renderTargetId = IntPtr.Zero;
+			}
 
-            _lastRenderTarget = null;
-        }
+			_lastRenderTarget = null;
+		}
 
-        void ClearLists()
-        {
-            _drawCommands.Clear();
-            _entityInspectors.Clear();
-        }
+		void ClearLists()
+		{
+			_drawCommands.Clear();
+			_entityInspectors.Clear();
+		}
 
-        /// <summary>
-        /// draws the game window and deals with overriding Nez.Input when appropriate
-        /// </summary>
-        void DrawGameWindow()
+		/// <summary>
+		/// draws the game window and deals with overriding Nez.Input when appropriate
+		/// </summary>
+		void DrawGameWindow()
 		{
 			if (_lastRenderTarget == null)
 				return;
@@ -303,8 +303,8 @@ namespace Nez.ImGuiTools
 		#region IFinalRenderDelegate
 
 		void IFinalRenderDelegate.HandleFinalRender(RenderTarget2D finalRenderTarget, Color letterboxColor,
-		                                            RenderTarget2D source, Rectangle finalRenderDestinationRect,
-		                                            SamplerState samplerState)
+													RenderTarget2D source, Rectangle finalRenderDestinationRect,
+													SamplerState samplerState)
 		{
 			if (ShowSeperateGameWindow)
 			{


### PR DESCRIPTION
As a proposal to solve https://github.com/prime31/Nez/issues/854

This reorganizes the Unload() method: splitting the render target reset and the clearing of lists into two distinct methods now. Going with the idea that the clearing of the lists may only need to happen after an explicit scene change event.

maybe `ResetRenderTarget` could be more-appropriately named. lmk.