### PR TITLE
ImGuiManager - fix removing Renderer/PostProcessor

### DIFF
--- a/Nez.ImGui/Inspectors/SceneGraphPanes/PostProcessorsPane.cs
+++ b/Nez.ImGui/Inspectors/SceneGraphPanes/PostProcessorsPane.cs
@@ -22,11 +22,11 @@ namespace Nez.ImGuiTools.SceneGraphPanes
 			if (!_isPostProcessorListInitialized || Time.FrameCount % 60 == 0)
 			{
 				_isPostProcessorListInitialized = true;
+
 				for (var i = 0; i < Core.Scene._postProcessors.Length; i++)
 				{
 					var postProcessor = Core.Scene._postProcessors.Buffer[i];
-					if (_postProcessorInspectors.Where(inspector => inspector.PostProcessor == postProcessor).Count() ==
-					    0)
+					if (_postProcessorInspectors.Where(inspector => inspector.PostProcessor == postProcessor).Count() == 0)
 						_postProcessorInspectors.Add(new PostProcessorInspector(postProcessor));
 				}
 			}
@@ -44,13 +44,18 @@ namespace Nez.ImGuiTools.SceneGraphPanes
 			UpdatePostProcessorInspectorList();
 
 			ImGui.Indent();
+
 			for (var i = 0; i < _postProcessorInspectors.Count; i++)
 			{
-				if (_postProcessorInspectors[i].PostProcessor._scene != null)
+				// watch out for removed PostProcessors
+				if (_postProcessorInspectors[i].PostProcessor._scene == null)
 				{
-					_postProcessorInspectors[i].Draw();
-					NezImGui.SmallVerticalSpace();
+					_postProcessorInspectors.RemoveAt(i);
+					continue;
 				}
+				
+				_postProcessorInspectors[i].Draw();
+				NezImGui.SmallVerticalSpace();
 			}
 
 			if (_postProcessorInspectors.Count == 0)
@@ -75,8 +80,7 @@ namespace Nez.ImGuiTools.SceneGraphPanes
 				{
 					if (ImGui.Selectable(subclassType.Name))
 					{
-						var postprocessor = (PostProcessor) Activator.CreateInstance(subclassType,
-							new object[] {_postProcessorInspectors.Count});
+						var postprocessor = (PostProcessor)Activator.CreateInstance(subclassType, new object[] { _postProcessorInspectors.Count });
 						Core.Scene.AddPostProcessor(postprocessor);
 						_isPostProcessorListInitialized = false;
 					}

--- a/Nez.ImGui/Inspectors/SceneGraphPanes/RenderersPane.cs
+++ b/Nez.ImGui/Inspectors/SceneGraphPanes/RenderersPane.cs
@@ -22,6 +22,7 @@ namespace Nez.ImGuiTools.SceneGraphPanes
 			if (!_isRendererListInitialized || Time.FrameCount % 60 == 0)
 			{
 				_isRendererListInitialized = true;
+
 				for (var i = 0; i < Core.Scene._renderers.Length; i++)
 				{
 					var renderer = Core.Scene._renderers.Buffer[i];
@@ -45,6 +46,13 @@ namespace Nez.ImGuiTools.SceneGraphPanes
 			ImGui.Indent();
 			for (var i = 0; i < _renderers.Count; i++)
 			{
+				// watch out for removed Renderers
+				if (_renderers[i].Renderer.Scene == null)
+				{
+					_renderers.RemoveAt(i);
+					continue;
+				}
+
 				_renderers[i].Draw();
 				NezImGui.SmallVerticalSpace();
 			}


### PR DESCRIPTION
removing Renderer or PostProcessor entries from the inspector panes in ImGuiManager was only half functional before. And removing them twice cause exception. now the items are removed from the scene and the inspector lists are properly cleaned up