### PR TITLE
accessible `Scene` properties for Renderer, SceneComponent...

### DIFF
--- a/Nez.Portable/ECS/Scene.cs
+++ b/Nez.Portable/ECS/Scene.cs
@@ -833,6 +833,7 @@ namespace Nez
 		{
 			Insist.IsTrue(_sceneComponents.Contains(component), "SceneComponent {0} is not in the SceneComponents list!", component);
 			_sceneComponents.Remove(component);
+			component.Scene = null;
 			component.OnRemovedFromScene();
 		}
 
@@ -859,6 +860,7 @@ namespace Nez
 				_renderers.Sort();
 			}
 
+			renderer.Scene = this;
 			renderer.OnAddedToScene(this);
 
 			// if we already began let the PostProcessor know what size our RenderTarget is
@@ -901,6 +903,7 @@ namespace Nez
 				_afterPostProcessorRenderers.Remove(renderer);
 			else
 				_renderers.Remove(renderer);
+			renderer.Scene = null;
 			renderer.Unload();
 		}
 

--- a/Nez.Portable/ECS/Scene.cs
+++ b/Nez.Portable/ECS/Scene.cs
@@ -903,6 +903,7 @@ namespace Nez
 				_afterPostProcessorRenderers.Remove(renderer);
 			else
 				_renderers.Remove(renderer);
+				
 			renderer.Scene = null;
 			renderer.Unload();
 		}

--- a/Nez.Portable/Graphics/Renderers/Renderer.cs
+++ b/Nez.Portable/Graphics/Renderers/Renderer.cs
@@ -70,6 +70,11 @@ namespace Nez
 		/// </summary>
 		protected Material _currentMaterial;
 
+		/// <summary>
+		/// the scene this Renderer is attached to
+		/// </summary>
+		public Scene Scene;
+
 
 		protected Renderer(int renderOrder) : this(renderOrder, null)
 		{}


### PR DESCRIPTION
Render, SceneComponent and PostProcessor now all contain references to their Scene. which is added and/or made null at appropriate times.