### PR TITLE
Added SDL3 Checks To Imgui To Fix Clipboard And Typing

### DIFF
--- a/Nez.ImGui/Core/ImGuiRenderer.cs
+++ b/Nez.ImGui/Core/ImGuiRenderer.cs
@@ -143,6 +143,7 @@ namespace Nez.ImGuiTools
 		{
 			ImGui.GetIO().DeltaTime = deltaTime;
 			UpdateInput();
+			CheckForTextInput();
 			ImGui.NewFrame();
 		}
 
@@ -167,9 +168,29 @@ namespace Nez.ImGuiTools
 		delegate string GetClipboardTextDelegate();
 		delegate void SetClipboardTextDelegate(IntPtr userData, string txt);
 
-		static void SetClipboardText(IntPtr userData, string txt) => SDL2.SDL.SDL_SetClipboardText(txt);
+		static void SetClipboardText(IntPtr userData, string txt)
+		{
+			try
+			{
+				SDL3.SDL.SDL_SetClipboardText(txt);
+			}
+			catch (DllNotFoundException)
+			{
+				SDL2.SDL.SDL_SetClipboardText(txt);
+			}
+		}
 
-		static string GetClipboardText() => SDL2.SDL.SDL_GetClipboardText();
+		static string GetClipboardText()
+		{
+			try
+			{
+				return SDL3.SDL.SDL_GetClipboardText();
+			}
+			catch (DllNotFoundException)
+			{
+				return SDL2.SDL.SDL_GetClipboardText();
+			}
+		}
 #endif
 
 		/// <summary>
@@ -182,7 +203,14 @@ namespace Nez.ImGuiTools
 #if FNA
 			// forward clipboard methods to SDL
 			io.SetClipboardTextFn = Marshal.GetFunctionPointerForDelegate<SetClipboardTextDelegate>(SetClipboardText);
-			io.GetClipboardTextFn = Marshal.GetFunctionPointerForDelegate<GetClipboardTextDelegate>(SDL2.SDL.SDL_GetClipboardText);
+			try
+			{
+				io.GetClipboardTextFn = Marshal.GetFunctionPointerForDelegate<GetClipboardTextDelegate>(SDL3.SDL.SDL_GetClipboardText);
+			}
+			catch (DllNotFoundException)
+			{
+				io.GetClipboardTextFn = Marshal.GetFunctionPointerForDelegate<GetClipboardTextDelegate>(SDL2.SDL.SDL_GetClipboardText);
+			}
 #endif
 
 			_keys.Add(io.KeyMap[(int)ImGuiKey.Tab] = (int)Keys.Tab);
@@ -416,6 +444,25 @@ namespace Nez.ImGuiTools
 				}
 
 				vtxOffset += cmdList.VtxBuffer.Size;
+			}
+		}
+
+		/// <summary>
+		/// SDL3 requires you to manually start/stop text input, SDL2 does not
+		/// </summary>
+		void CheckForTextInput()
+		{
+			try
+			{
+				_ = SDL3.SDL.SDL_GetVersion();
+				if (ImGui.GetIO().WantTextInput && !TextInputEXT.IsTextInputActive())
+					TextInputEXT.StartTextInput();
+				else if (!ImGui.GetIO().WantTextInput && TextInputEXT.IsTextInputActive())
+					TextInputEXT.StopTextInput();
+			}
+			catch (DllNotFoundException)
+			{
+				return;
 			}
 		}
 


### PR DESCRIPTION
Small PR that adds a few try/catches to swap SDL2 calls with SDL3 for developers on newer FNA since the full swap to SDL3, whilst retaining original functionality.

This in specific addresses an issue with typing, as SDL3 changed the default behaviour to turn on/off typing (for things like onscreen keyboards and similar), in addition fixing the clipboard to use the proper SDL version one.