### PR TITLE
add color vignette postprocessor

### DIFF
--- a/DefaultContentSource/effects/ColorVignette.fx
+++ b/DefaultContentSource/effects/ColorVignette.fx
@@ -1,0 +1,25 @@
+sampler s0;
+
+float _power; // 1.0
+float _radius; // 1.25
+float4 _color;
+
+float4 mainPS( float2 texCoord:TEXCOORD0 ) : COLOR0
+{
+	float4 color = tex2D( s0, texCoord );
+	float2 dist = ( texCoord - 0.5f ) * _radius;
+	dist.x = 1 - dot( dist, dist ) * _power;
+	color.rgb *= saturate( dist.x + _color );
+
+	return color;
+}
+
+
+
+technique ColorVignette
+{
+	pass P0
+	{
+		PixelShader = compile ps_3_0 mainPS();
+	}
+};

--- a/Nez.Portable/Graphics/Effects/EffectResource.cs
+++ b/Nez.Portable/Graphics/Effects/EffectResource.cs
@@ -33,6 +33,8 @@ namespace Nez
 
 		internal static byte[] GaussianBlurBytes => GetFileResourceBytes("Content/nez/effects/GaussianBlur.mgfxo");
 
+		internal static byte[] ColorVignetteBytes => GetFileResourceBytes("Content/nez/effects/ColorVignette.mgfxo");
+
 		internal static byte[] VignetteBytes => GetFileResourceBytes("Content/nez/effects/Vignette.mgfxo");
 
 		internal static byte[] LetterboxBytes => GetFileResourceBytes("Content/nez/effects/Letterbox.mgfxo");

--- a/Nez.Portable/Graphics/PostProcessing/PostProcessors/ColorVignettePostProcessor.cs
+++ b/Nez.Portable/Graphics/PostProcessing/PostProcessors/ColorVignettePostProcessor.cs
@@ -1,0 +1,86 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+
+namespace Nez
+{
+    public class ColorVignettePostProcessor : PostProcessor
+    {
+        public Color Color
+        {
+            get => _color;
+            set
+            {
+                if (_color != value)
+                {
+                    _color = value;
+                    _colorParam.SetValue(_color.ToVector4());
+                }
+            }
+        }
+
+        [Range(0.001f, 10f, 0.001f)]
+        public float Power
+        {
+            get => _power;
+            set
+            {
+                if (_power != value)
+                {
+                    _power = value;
+
+                    if (Effect != null)
+                        _powerParam.SetValue(_power);
+                }
+            }
+        }
+
+        [Range(0.001f, 10f, 0.001f)]
+        public float Radius
+        {
+            get => _radius;
+            set
+            {
+                if (_radius != value)
+                {
+                    _radius = value;
+
+                    if (Effect != null)
+                        _radiusParam.SetValue(_radius);
+                }
+            }
+        }
+
+        float _power = 1f;
+        float _radius = 1.25f;
+        Color _color = Color.Black;
+        EffectParameter _powerParam;
+        EffectParameter _radiusParam;
+        EffectParameter _colorParam;
+
+
+        public ColorVignettePostProcessor(int executionOrder) : base(executionOrder)
+        {
+        }
+
+        public override void OnAddedToScene(Scene scene)
+        {
+            base.OnAddedToScene(scene);
+
+            Effect = scene.Content.LoadEffect<Effect>("color-vignette", EffectResource.ColorVignetteBytes);
+
+            _powerParam = Effect.Parameters["_power"];
+            _radiusParam = Effect.Parameters["_radius"];
+            _colorParam = Effect.Parameters["_color"];
+            _powerParam.SetValue(_power);
+            _radiusParam.SetValue(_radius);
+            _colorParam.SetValue(_color.ToVector4());
+        }
+
+        public override void Unload()
+        {
+            _scene.Content.UnloadEffect(Effect);
+            base.Unload();
+        }
+    }
+}


### PR DESCRIPTION
a variant on the Vignette post-processor. This one allows you to set a color for the vignette effect so the edges can be something other than black - tho it is black by default so it behaves just like the original out-of-the-box
@prime31 will need to compile shaders so we have mgofx/fxb resource bytes
and maybe consider just having this ColorVignette effect replace the Vignette one entirely.