### PR TITLE
More scene transitions

### DIFF
--- a/DefaultContentSource/effects/transitions/Bounce.fx
+++ b/DefaultContentSource/effects/transitions/Bounce.fx
@@ -1,0 +1,45 @@
+// Author: Adrian Purser
+// License: MIT
+
+// https://gl-transitions.com/editor/Bounce
+// https://github.com/gl-transitions/gl-transitions/blob/master/transitions/Bounce.glsl
+
+// Converted to HLSL/XNA for Nez
+
+sampler s0;
+
+float _progress; // 0
+
+float4 _shadowColor; // float4(0, 0, 0, 0.6)
+float _shadowHeight; // 0.075
+float _bounces;      // 3.0
+
+#define PI 3.14159265358
+
+float4 mainPS(float2 uv : TEXCOORD0) : COLOR0
+{
+	float stime = sin(_progress * PI / 2.0);
+	float phase = _progress * PI * _bounces;
+	float y = (abs(cos(phase))) * (1.0 - stime);
+	float d = 1.0 - uv.y - y;
+
+	return lerp(
+		lerp(0.0, _shadowColor,
+			 step(d, _shadowHeight) * (1.0 - lerp(
+				 ((d / _shadowHeight) * _shadowColor.a) + (1.0 - _shadowColor.a),
+				 1.0,
+				smoothstep(0.8, 1.0, _progress) // fade-out the shadow at the end
+			))
+		),
+		tex2D(s0, float2(uv.x, uv.y + y)),
+		step(d, 0.0)
+	);
+}
+
+technique Bounce
+{
+	pass P0
+	{
+		PixelShader = compile ps_2_0 mainPS();
+	}
+}

--- a/DefaultContentSource/effects/transitions/CircleCrop.fx
+++ b/DefaultContentSource/effects/transitions/CircleCrop.fx
@@ -1,0 +1,36 @@
+// Author: fkuteken
+// License: MIT
+// ported by gre from https://gist.github.com/fkuteken/f63e3009c1143950dee9063c3b83fb88
+
+// https://gl-transitions.com/editor/CircleCrop
+// https://github.com/gl-transitions/gl-transitions/tree/master/transitions/CircleCrop.glsl
+
+// Converted to HLSL/XNA for Nez
+
+sampler s0;
+
+float _progress; // 0
+float _ratio;    // Screen.Width/Height
+
+float4 _bgcolor; // = vec4(0.0, 0.0, 0.0, 1.0)
+
+float4 mainPS(float2 uv : TEXCOORD0) : COLOR0
+{
+	float dist = length((float2(uv.x, uv.y) - 0.5) * float2(1.0, 1.0 / _ratio));
+
+	// branching is ok here as we statically depend on progress uniform
+	// (branching won't change over pixels)
+	return lerp(
+		_progress < 0.5 ? tex2D(s0, uv) : 0,
+		_bgcolor,
+		step(pow(2.0 * abs(_progress - 0.5), 3.0), dist)
+	);
+}
+
+technique CircleCrop
+{
+	pass P0
+	{
+		PixelShader = compile ps_2_0 mainPS();
+	}
+}

--- a/DefaultContentSource/effects/transitions/DirectionalWipe.fx
+++ b/DefaultContentSource/effects/transitions/DirectionalWipe.fx
@@ -1,0 +1,36 @@
+// Author: gre
+// License: MIT
+
+// https://gl-transitions.com/editor/directionalwipe
+// https://github.com/gl-transitions/gl-transitions/blob/master/transitions/directionalwipe.glsl
+
+// Converted to HLSL/XNA for Nez
+
+sampler s0;
+
+float _progress; // 0
+
+float2 _direction; // float2(1.0, 1.0) Normalized
+float _smoothness; // 0.5 (0 - 1.0)
+
+static float2 _center = float2(0.5, 0.5);
+
+float4 mainPS(float2 uv : TEXCOORD0) : COLOR0
+{
+
+	float2 v = normalize(_direction);
+	v /= abs(v.x) + abs(v.y);
+	float d = v.x * _center.x + v.y * _center.y;
+	float m =
+		(1.0 - step(_progress, 0.0)) *
+		(1.0 - smoothstep(-_smoothness, 0.0, v.x * uv.x + v.y * uv.y - (d - 0.5 + _progress * (1.0 + _smoothness))));
+	return lerp(tex2D(s0, uv), 0, m);
+}
+
+technique DirectionalWipe
+{
+	pass P0
+	{
+		PixelShader = compile ps_2_0 mainPS();
+	}
+}

--- a/DefaultContentSource/effects/transitions/Doom.fx
+++ b/DefaultContentSource/effects/transitions/Doom.fx
@@ -1,0 +1,86 @@
+// Author: Zeh Fernando
+// License: MIT
+
+// https://gl-transitions.com/editor/DoomScreenTransition
+// https://github.com/gl-transitions/gl-transitions/blob/master/transitions/DoomScreenTransition.glsl
+
+// Converted to HLSL/XNA for Nez
+
+sampler s0;
+
+float _progress; // 0
+
+#define mod(x, y) x - (y * floor(x / y))
+
+// Transition parameters --------
+
+// Number of total bars/columns
+float _bars; // = 30
+
+// Multiplier for speed ratio. 0 = no variation when going down, higher = some elements go much faster
+float _amplitude; // = 2
+
+// Further variations in speed. 0 = no noise, 1 = super noisy (ignore frequency)
+float _noise; // = 0.1
+
+// Speed variation horizontally. the bigger the value, the shorter the waves
+float _frequency; // = 0.5
+
+// How much the bars seem to "run" from the middle of the screen first (sticking to the sides). 0 = no drip, 1 = curved
+// drip
+float _dripScale; // = 0.5
+
+// The code proper --------
+
+float rand(int num)
+{
+	return frac(mod(float(num) * 67123.313, 12.0) * sin(float(num) * 10.3) * cos(float(num)));
+}
+
+float wave(int num)
+{
+	float fn = float(num) * _frequency * 0.1 * float(_bars);
+	return cos(fn * 0.5) * cos(fn * 0.13) * sin((fn + 10.0) * 0.3) / 2.0 + 0.5;
+}
+
+float drip(int num)
+{
+	return sin(float(num) / float(_bars - 1) * 3.141592) * _dripScale;
+}
+
+float pos(int num)
+{
+	return (_noise == 0.0 ? wave(num) : lerp(wave(num), rand(num), _noise)) 
+		+ (_dripScale == 0.0 ? 0.0 : drip(num));
+}
+
+float4 mainPS(float2 uv : TEXCOORD0) : COLOR0
+{
+	int bar = int(uv.x * float(_bars));
+	float scale = 1.0 + pos(bar) * _amplitude;
+	float phase = _progress * scale;
+	float posY = (1.0 - uv.y) / 1.0;
+	float2 p;
+	float4 c;
+	if (phase + posY < 1.0)
+	{
+		p = float2(uv.x, uv.y - lerp(0.0, 1.0, phase)) / 1.0;
+		c = tex2D(s0, p);
+	}
+	else
+	{
+		p = uv.xy / 1.0;
+		c = 0.0;
+	}
+
+	// Finally, apply the color
+	return c;
+}
+
+technique Doom
+{
+	pass P0
+	{
+		PixelShader = compile ps_2_0 mainPS();
+	}
+}

--- a/DefaultContentSource/effects/transitions/Kaleidoscope.fx
+++ b/DefaultContentSource/effects/transitions/Kaleidoscope.fx
@@ -1,0 +1,51 @@
+// Author: nwoeanhinnogaehr
+// License: MIT
+
+// https://gl-transitions.com/editor/kaleidoscope
+// https://github.com/gl-transitions/gl-transitions/tree/master/transitions/kaleidoscope.glsl
+
+// Converted to HLSL/XNA for Nez
+
+sampler s0;
+
+float _progress; // 0
+
+float _speed; // 1.0;
+float _angle; // 1.0;
+float _power; // 1.5;
+
+static float2 _center = float2(0.5, 0.5);
+
+#define PI 3.14159265359
+#define TWOPI PI * 2.0
+#define mod(x, y) x - (y * floor(x / y))
+
+float4 mainPS(float2 uv : TEXCOORD0) : COLOR0
+{
+
+	float2 p = uv.xy / 1.0;
+	float2 q = p;
+	float t = pow(_progress, _power) * _speed;
+	p = p - 0.5;
+	for (int i = 0; i < 7; i++)
+	{
+		p = float2(sin(t) * p.x + cos(t) * p.y, sin(t) * p.y - cos(t) * p.x);
+		t += _angle;
+		p = abs(mod(p, 2.0) - 1.0);
+	}
+	p = abs(mod(p, 1.0));
+
+	return lerp(
+		lerp(tex2D(s0, q), 0, _progress),
+		lerp(tex2D(s0, p), 0, _progress),
+		1.0 - 2.0 * abs(_progress - 0.5)
+	);
+}
+
+technique Kaleidoscope
+{
+	pass P0
+	{
+		PixelShader = compile ps_2_0 mainPS();
+	}
+}

--- a/DefaultContentSource/effects/transitions/Perlin.fx
+++ b/DefaultContentSource/effects/transitions/Perlin.fx
@@ -1,0 +1,73 @@
+// Author: Rich Harris
+// License: MIT
+
+// https://gl-transitions.com/editor/perlin
+// https://github.com/gl-transitions/gl-transitions/tree/master/transitions/perlin.glsl
+
+// Converted to HLSL/XNA for Nez
+
+sampler s0;
+
+float _progress; // 0
+
+float _scale;      // = 4.0
+float _smoothness; // = 0.01
+
+float _seed; // = 12.9898
+
+#define mod(x, y) x - (y * floor(x / y))
+
+// http://byteblacksmith.com/improvements-to-the-canonical-one-liner-glsl-rand-for-opengl-es-2-0/
+float random(float2 co)
+{
+		float a = _seed;
+		float b = 78.233;
+		float c = 43758.5453;
+		float dt = dot(co.xy, float2(a, b));
+		float sn = mod(dt, 3.14);
+		return frac(sin(sn) * c);
+}
+
+// 2D Noise based on Morgan McGuire @morgan3d
+// https://www.shadertoy.com/view/4dS3Wd
+float noise(float2 st)
+{
+		float2 i = floor(st);
+		float2 f = frac(st);
+
+		// Four corners in 2D of a tile
+		float a = random(i);
+		float b = random(i + float2(1.0, 0.0));
+		float c = random(i + float2(0.0, 1.0));
+		float d = random(i + float2(1.0, 1.0));
+
+		// Smooth Interpolation
+
+		// Cubic Hermine Curve.  Same as SmoothStep()
+		float2 u = f * f * (3.0 - 2.0 * f);
+		// u = smoothstep(0.,1.,f);
+
+		// Mix 4 corners percentages
+		return lerp(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
+}
+
+float4 mainPS(float2 uv : TEXCOORD0) : COLOR0
+{
+		float n = noise(uv * _scale);
+
+		float p = lerp(-_smoothness, 1.0 + _smoothness, _progress);
+		float lower = p - _smoothness;
+		float higher = p + _smoothness;
+
+		float q = smoothstep(lower, higher, n);
+
+		return lerp(tex2D(s0, uv), 0.0, 1.0 - q);
+}
+
+technique Perlin
+{
+		pass P0
+		{
+				PixelShader = compile ps_2_0 mainPS();
+		}
+}

--- a/DefaultContentSource/effects/transitions/PolkaDotsCurtain.fx
+++ b/DefaultContentSource/effects/transitions/PolkaDotsCurtain.fx
@@ -10,18 +10,17 @@ sampler s0;
 
 float _progress; // 0
 
-static float _sqrt2 = 1.414213562373;
-
 float _dots;    // 20.0;
 float2 _center; // float2(0, 0);
+float _ratio; // Screen.Width/Height
 
 float4 mainPS(float2 uv : TEXCOORD0) : COLOR0
 {
-	if (distance(frac(uv * _dots), 0.5) >= (_progress / distance(uv, _center)))
+	if (distance(frac(uv * _dots * float2(1.0, 1.0 / _ratio)), 0.5) >= (_progress / distance(uv, _center)))
 	{
 		return tex2D(s0, uv);
 	}
-	
+
 	return 0;
 }
 

--- a/DefaultContentSource/effects/transitions/PolkaDotsCurtain.fx
+++ b/DefaultContentSource/effects/transitions/PolkaDotsCurtain.fx
@@ -1,0 +1,34 @@
+// Author: bobylito
+// License: MIT
+
+// https://gl-transitions.com/editor/PolkaDotsCurtain
+// https://github.com/gl-transitions/gl-transitions/blob/master/transitions/PolkaDotsCurtain.glsl
+
+// Converted to HLSL/XNA for Nez
+
+sampler s0;
+
+float _progress; // 0
+
+static float _sqrt2 = 1.414213562373;
+
+float _dots;    // 20.0;
+float2 _center; // float2(0, 0);
+
+float4 mainPS(float2 uv : TEXCOORD0) : COLOR0
+{
+	if (distance(frac(uv * _dots), 0.5) >= (_progress / distance(uv, _center)))
+	{
+		return tex2D(s0, uv);
+	}
+	
+	return 0;
+}
+
+technique PolkaDotsCurtain
+{
+	pass P0
+	{
+		PixelShader = compile ps_2_0 mainPS();
+	}
+}

--- a/DefaultContentSource/effects/transitions/SimpleZoom.fx
+++ b/DefaultContentSource/effects/transitions/SimpleZoom.fx
@@ -1,0 +1,29 @@
+// Author: 0gust1
+// License: MIT
+
+// https://gl-transitions.com/editor/SimpleZoom
+// https://github.com/gl-transitions/gl-transitions/tree/master/transitions/SimpleZoom.glsl
+
+// Converted to HLSL/XNA for Nez
+
+sampler s0;
+
+float _progress; // 0
+
+float _zoomQuickness; // 0.8 (0.2 - 1.0)
+
+float4 mainPS(float2 uv : TEXCOORD0) : COLOR0
+{
+
+		float2 zoom = 0.5 + (uv - 0.5) * (1.0 - smoothstep(0.0, _zoomQuickness, _progress));
+
+		return lerp(tex2D(s0, zoom), 0, smoothstep(_zoomQuickness - 0.2, 1.0, _progress));
+}
+
+technique SimpleZoom
+{
+		pass P0
+		{
+				PixelShader = compile ps_2_0 mainPS();
+		}
+}

--- a/DefaultContentSource/effects/transitions/WaterDrop.fx
+++ b/DefaultContentSource/effects/transitions/WaterDrop.fx
@@ -1,0 +1,38 @@
+// Author: Paweł Płóciennik
+// License: MIT
+
+// https://gl-transitions.com/editor/WaterDrop
+// https://github.com/gl-transitions/gl-transitions/blob/master/transitions/WaterDrop.glsl
+
+// Converted to HLSL/XNA for Nez
+
+sampler s0;
+
+float _progress; // 0
+
+float _amplitude; // 30.0
+float _speed;     // 30.0;
+
+float4 mainPS(float2 uv : TEXCOORD0) : COLOR0
+{
+	float2 dir = uv - 0.5;
+	float dist = length(dir);
+
+	if (dist > _progress)
+	{
+		return lerp(tex2D(s0, uv), 0, _progress);
+	}
+	else
+	{
+		float2 offset = dir * sin(dist * _amplitude - _progress * _speed);
+		return lerp(tex2D(s0, uv + offset), 0, _progress);
+	}
+}
+
+technique WaterDrop
+{
+	pass P0
+	{
+		PixelShader = compile ps_2_0 mainPS();
+	}
+}

--- a/DefaultContentSource/effects/transitions/WindowBlinds.fx
+++ b/DefaultContentSource/effects/transitions/WindowBlinds.fx
@@ -1,0 +1,31 @@
+// Author: Fabien Benetou
+// License: MIT
+
+// https://gl-transitions.com/editor/windowblinds
+// https://github.com/gl-transitions/gl-transitions/tree/master/transitions/windowblinds.glsl
+
+// Converted to HLSL/XNA for Nez
+
+sampler s0;
+
+float _progress; // 0
+
+#define mod(x, y) x - (y * floor(x / y))
+
+float4 mainPS(float2 uv : TEXCOORD0) : COLOR0
+{
+    float t = _progress;
+
+    if (mod(floor(uv.y * 50.0 * _progress), 2.0) == 0.0)
+        t *= 2.0 - 0.5;
+
+    return lerp(tex2D(s0, uv), 0.0, lerp(t, _progress, smoothstep(0.8, 1.0, _progress)));
+}
+
+technique WindowBlinds
+{
+    pass P0
+    {
+        PixelShader = compile ps_2_0 mainPS();
+    }
+}

--- a/DefaultContentSource/effects/transitions/WindowSlice.fx
+++ b/DefaultContentSource/effects/transitions/WindowSlice.fx
@@ -1,0 +1,29 @@
+// Author: gre
+// License: MIT
+
+// https://gl-transitions.com/editor/windowslice
+// https://github.com/gl-transitions/gl-transitions/tree/master/transitions/windowslice.glsl
+
+// Converted to HLSL/XNA for Nez
+
+sampler s0;
+
+float _progress; // 0
+
+float _count;      // 10 (1 - 100)
+float _smoothness; // 0.5 (0.0 - 1.0)
+
+float4 mainPS(float2 uv : TEXCOORD0) : COLOR0
+{
+	float pr = smoothstep(-_smoothness, 0.0, uv.x - _progress * (1.0 + _smoothness));
+	float s = step(pr, frac(_count * uv.x));
+	return lerp(tex2D(s0, uv), 0, s);
+}
+
+technique WindowSlice
+{
+	pass P0
+	{
+		PixelShader = compile ps_2_0 mainPS();
+	}
+}

--- a/Nez.Portable/Graphics/Transitions/BounceTransition.cs
+++ b/Nez.Portable/Graphics/Transitions/BounceTransition.cs
@@ -9,27 +9,36 @@ using Nez.Tweens;
 namespace Nez
 {
 	/// <summary>
-	/// A cascade of opening vertical blinds
-	/// based on: https://gl-transitions.com/editor/windowslice
+	/// Screen falls down and bounces at the bottom
+	/// based on: https://gl-transitions.com/editor/Bounce
 	/// </summary>
-	public class WindowSliceTransition : SceneTransition
+	public class BounceTransition : SceneTransition
 	{
 		/// <summary>
-		/// Number of window slices. Defaults to 10. (1 - 100)
+		/// Color of the dropshadow. Uses alpha. Defaults to Color.FromNonPremultiplied(0, 0, 0, 153).
 		/// </summary>
-		/// <value>The number of slices.</value>
-		public float Count
+		/// <value>The color of the dropshadow.</value>
+		public Vector4 ShadowColor
 		{
-			set => _effect.Parameters["_count"].SetValue(value);
+			set => _effect.Parameters["_shadowColor"].SetValue(value);
 		}
 
 		/// <summary>
-		/// Duration and speed of each slice. Defaults to 0.5. (0.0 - 1.0) 
+		/// The height of the dropshadow. Defaults to 0.075 (0.0 - 1.0)
 		/// </summary>
-		/// <value>The smoothness amount.</value>
-		public float Smoothness
+		/// <value>The height of the dropshadow.</value>
+		public float ShadowHeight
 		{
-			set => _effect.Parameters["_smoothness"].SetValue(value);
+			set => _effect.Parameters["_shadowHeight"].SetValue(value);
+		}
+
+		/// <summary>
+		/// Number of times to bounce. Defaults to 3.
+		/// </summary>
+		/// <value>The number of bounces</value>
+		public float Bounces
+		{
+			set => _effect.Parameters["_bounces"].SetValue(value);
 		}
 
 		/// <summary>
@@ -45,18 +54,18 @@ namespace Nez
 		Effect _effect;
 		Rectangle _destinationRect;
 
-
-		public WindowSliceTransition(Func<Scene> sceneLoadAction) : base(sceneLoadAction, true)
+		public BounceTransition(Func<Scene> sceneLoadAction) : base(sceneLoadAction, true)
 		{
 			_destinationRect = PreviousSceneRender.Bounds;
 
 			// load Effect and set defaults
-			_effect = Core.Content.LoadEffect("Content/nez/effects/transitions/WindowSlice.mgfxo");
-			Count = 10;
-			Smoothness = 0.5f;
+			_effect = Core.Content.LoadEffect("Content/nez/effects/transitions/Bounce.mgfxo");
+			ShadowColor = new Vector4(0, 0, 0, 0.6f);
+			ShadowHeight = 0.075f;
+			Bounces = 3;
 		}
 
-		public WindowSliceTransition() : this(null)
+		public BounceTransition() : this(null)
 		{ }
 
 		public override IEnumerator OnBeginTransition()

--- a/Nez.Portable/Graphics/Transitions/CircleCropTransition.cs
+++ b/Nez.Portable/Graphics/Transitions/CircleCropTransition.cs
@@ -9,27 +9,27 @@ using Nez.Tweens;
 namespace Nez
 {
 	/// <summary>
-	/// A cascade of opening vertical blinds
-	/// based on: https://gl-transitions.com/editor/windowslice
+	/// Circle collapsing to black wipe.
+	/// based on: https://gl-transitions.com/editor/CircleCrop
 	/// </summary>
-	public class WindowSliceTransition : SceneTransition
+	public class CircleCropTransition : SceneTransition
 	{
 		/// <summary>
-		/// Number of window slices. Defaults to 10. (1 - 100)
+		/// Aspect ratio of the screen. Defaults to Screen.Width/Height
 		/// </summary>
-		/// <value>The number of slices.</value>
-		public float Count
+		/// <value>Ratio of the screen.</value>
+		public float Ratio
 		{
-			set => _effect.Parameters["_count"].SetValue(value);
+			set => _effect.Parameters["_ratio"].SetValue(value);
 		}
 
 		/// <summary>
-		/// Duration and speed of each slice. Defaults to 0.5. (0.0 - 1.0) 
+		/// Background color. Defaults to Black
 		/// </summary>
-		/// <value>The smoothness amount.</value>
-		public float Smoothness
+		/// <value>The color for the background.</value>
+		public Color BgColor
 		{
-			set => _effect.Parameters["_smoothness"].SetValue(value);
+			set => _effect.Parameters["_bgcolor"].SetValue(value.ToVector4());
 		}
 
 		/// <summary>
@@ -45,24 +45,21 @@ namespace Nez
 		Effect _effect;
 		Rectangle _destinationRect;
 
-
-		public WindowSliceTransition(Func<Scene> sceneLoadAction) : base(sceneLoadAction, true)
+		public CircleCropTransition(Func<Scene> sceneLoadAction) : base(sceneLoadAction, true)
 		{
 			_destinationRect = PreviousSceneRender.Bounds;
 
 			// load Effect and set defaults
-			_effect = Core.Content.LoadEffect("Content/nez/effects/transitions/WindowSlice.mgfxo");
-			Count = 10;
-			Smoothness = 0.5f;
+			_effect = Core.Content.LoadEffect("Content/nez/effects/transitions/CircleCrop.mgfxo");
+			Ratio = (float)Screen.Width / Screen.Height;
+			BgColor = Color.Black;
 		}
 
-		public WindowSliceTransition() : this(null)
+		public CircleCropTransition() : this(null)
 		{ }
 
 		public override IEnumerator OnBeginTransition()
 		{
-			yield return null;
-
 			// load up the new Scene
 			yield return Core.StartCoroutine(LoadNextScene());
 

--- a/Nez.Portable/Graphics/Transitions/DirectionalWipeTransition.cs
+++ b/Nez.Portable/Graphics/Transitions/DirectionalWipeTransition.cs
@@ -56,6 +56,9 @@ namespace Nez
 			Smoothness = 0.5f;
 		}
 
+		public DirectionalWipeTransition() : this(null)
+		{ }
+
 		public override IEnumerator OnBeginTransition()
 		{
 			yield return null;

--- a/Nez.Portable/Graphics/Transitions/DirectionalWipeTransition.cs
+++ b/Nez.Portable/Graphics/Transitions/DirectionalWipeTransition.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using Nez.Tweens;
+
+namespace Nez
+{
+	/// <summary>
+	/// Star Wars style screen wipe
+	/// based on: https://gl-transitions.com/editor/directionalwipe
+	/// </summary>
+	public class DirectionalWipeTransition : SceneTransition
+	{
+		/// <summary>
+		/// Direction of the wipe. Defaults to Vector2(1, 1) "Down-right"
+		/// </summary>
+		/// <value>The Normalized Vector2 direction.</value>
+		public Vector2 Direction
+		{
+			set => _effect.Parameters["_direction"].SetValue(value);
+		}
+
+		/// <summary>
+		/// How much to blur the wiper. Defaults to 0.5. (0.0 - 1.0) 
+		/// </summary>
+		/// <value>The smoothness amount.</value>
+		public float Smoothness
+		{
+			set => _effect.Parameters["_smoothness"].SetValue(value);
+		}
+
+		/// <summary>
+		/// duration for the transition
+		/// </summary>
+		public float Duration = 1f;
+
+		/// <summary>
+		/// ease equation to use for the animation
+		/// </summary>
+		public EaseType EaseType = EaseType.Linear;
+
+		Effect _effect;
+		Rectangle _destinationRect;
+
+
+		public DirectionalWipeTransition(Func<Scene> sceneLoadAction) : base(sceneLoadAction, true)
+		{
+			_destinationRect = PreviousSceneRender.Bounds;
+
+			// load Effect and set defaults
+			_effect = Core.Content.LoadEffect("Content/nez/effects/transitions/DirectionalWipe.mgfxo");
+			Direction = new Vector2(1, 1);
+			Smoothness = 0.5f;
+		}
+
+		public override IEnumerator OnBeginTransition()
+		{
+			yield return null;
+
+			// load up the new Scene
+			yield return Core.StartCoroutine(LoadNextScene());
+
+			// apply the effect
+			yield return Core.StartCoroutine(TickEffectProgressProperty(_effect, Duration, EaseType));
+
+			TransitionComplete();
+
+			// cleanup
+			Core.Content.UnloadEffect(_effect);
+		}
+
+		public override void Render(Batcher batcher)
+		{
+			Core.GraphicsDevice.SetRenderTarget(null);
+			batcher.Begin(BlendState.NonPremultiplied, Core.DefaultSamplerState, DepthStencilState.None, null, _effect);
+			batcher.Draw(PreviousSceneRender, _destinationRect, Color.White);
+			batcher.End();
+		}
+	}
+}

--- a/Nez.Portable/Graphics/Transitions/DoomTransition.cs
+++ b/Nez.Portable/Graphics/Transitions/DoomTransition.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using Nez.Tweens;
+
+namespace Nez
+{
+	/// <summary>
+	/// From the classic game DOOM
+	/// based on: https://gl-transitions.com/editor/DoomScreenTransition
+	/// </summary>
+	public class DoomTransition : SceneTransition
+	{
+		/// <summary>
+		/// Number of total bars/columns. Defaults to 30
+		/// </summary>
+		/// <value>The number of total bars/columns.</value>
+		public int Bars
+		{
+			set => _effect.Parameters["_bars"].SetValue(value);
+		}
+
+		/// <summary>
+		/// Multiplier for speed ratio. Defaults to 2
+		/// </summary>
+		/// <value>Multiplier for speed ratio. 0 = no variation when going down, higher = some elements go much faster.</value>
+		public float Amplitude
+		{
+			set => _effect.Parameters["_amplitude"].SetValue(value);
+		}
+
+		/// <summary>
+		/// Further variations in speed. Defaults to 0.1
+		/// </summary>
+		/// <value>Further variations in speed. 0 = no noise, 1 = super noisy (ignore frequency)</value>
+		public float Noise
+		{
+			set => _effect.Parameters["_noise"].SetValue(value);
+		}
+
+		/// <summary>
+		/// Speed variation horizontally. Defaults to 0.5
+		/// </summary>
+		/// <value>Speed variation horizontally. the bigger the value, the shorter the waves</value>
+		public float Frequency
+		{
+			set => _effect.Parameters["_frequency"].SetValue(value);
+		}
+
+		/// <summary>
+		/// Runniness of bars near the center. Defaults to 0.5
+		/// </summary>
+		/// <value>How much the bars seem to "run" from the middle of the screen first (sticking to the sides). 0 = no drip, 1 = curved drip</value>
+		public float DripScale
+		{
+			set => _effect.Parameters["_dripScale"].SetValue(value);
+		}
+
+		/// <summary>
+		/// duration for the transition
+		/// </summary>
+		public float Duration = 1f;
+
+		/// <summary>
+		/// ease equation to use for the animation
+		/// </summary>
+		public EaseType EaseType = EaseType.Linear;
+
+		Effect _effect;
+		Rectangle _destinationRect;
+
+		public DoomTransition(Func<Scene> sceneLoadAction) : base(sceneLoadAction, true)
+		{
+			_destinationRect = PreviousSceneRender.Bounds;
+
+			// load Effect and set defaults
+			_effect = Core.Content.LoadEffect("Content/nez/effects/transitions/Doom.mgfxo");
+			Bars = 30;
+			Amplitude = 2f;
+			Noise = 0.1f;
+			Frequency = 0.5f;
+			DripScale = 0.5f;
+		}
+
+		public DoomTransition() : this(null)
+		{ }
+
+		public override IEnumerator OnBeginTransition()
+		{
+			// load up the new Scene
+			yield return Core.StartCoroutine(LoadNextScene());
+
+			// apply the effect
+			yield return Core.StartCoroutine(TickEffectProgressProperty(_effect, Duration, EaseType));
+
+			TransitionComplete();
+
+			// cleanup
+			Core.Content.UnloadEffect(_effect);
+		}
+
+		public override void Render(Batcher batcher)
+		{
+			Core.GraphicsDevice.SetRenderTarget(null);
+			batcher.Begin(BlendState.NonPremultiplied, Core.DefaultSamplerState, DepthStencilState.None, null, _effect);
+			batcher.Draw(PreviousSceneRender, _destinationRect, Color.White);
+			batcher.End();
+		}
+	}
+}

--- a/Nez.Portable/Graphics/Transitions/KaleidoscopeTransition.cs
+++ b/Nez.Portable/Graphics/Transitions/KaleidoscopeTransition.cs
@@ -9,27 +9,36 @@ using Nez.Tweens;
 namespace Nez
 {
 	/// <summary>
-	/// A cascade of opening vertical blinds
-	/// based on: https://gl-transitions.com/editor/windowslice
+	/// Colorful twisting blurring transition
+	/// based on: https://gl-transitions.com/editor/kaleidoscope
 	/// </summary>
-	public class WindowSliceTransition : SceneTransition
+	public class KaleidoscopeTransition : SceneTransition
 	{
 		/// <summary>
-		/// Number of window slices. Defaults to 10. (1 - 100)
+		/// Speed of the rotation. Defaults to 1.0.
 		/// </summary>
-		/// <value>The number of slices.</value>
-		public float Count
+		/// <value>The speed of rotation.</value>
+		public float Speed
 		{
-			set => _effect.Parameters["_count"].SetValue(value);
+			set => _effect.Parameters["_speed"].SetValue(value);
 		}
 
 		/// <summary>
-		/// Duration and speed of each slice. Defaults to 0.5. (0.0 - 1.0) 
+		/// How much to twist. Defaults to 1.0.
 		/// </summary>
-		/// <value>The smoothness amount.</value>
-		public float Smoothness
+		/// <value>The rotation angle.</value>
+		public float Angle
 		{
-			set => _effect.Parameters["_smoothness"].SetValue(value);
+			set => _effect.Parameters["_angle"].SetValue(value);
+		}
+
+		/// <summary>
+		/// Power of the distortion. Defaults to 1.5.
+		/// </summary>
+		/// <value>The distortion power.</value>
+		public float Power
+		{
+			set => _effect.Parameters["_power"].SetValue(value);
 		}
 
 		/// <summary>
@@ -45,24 +54,22 @@ namespace Nez
 		Effect _effect;
 		Rectangle _destinationRect;
 
-
-		public WindowSliceTransition(Func<Scene> sceneLoadAction) : base(sceneLoadAction, true)
+		public KaleidoscopeTransition(Func<Scene> sceneLoadAction) : base(sceneLoadAction, true)
 		{
 			_destinationRect = PreviousSceneRender.Bounds;
 
 			// load Effect and set defaults
-			_effect = Core.Content.LoadEffect("Content/nez/effects/transitions/WindowSlice.mgfxo");
-			Count = 10;
-			Smoothness = 0.5f;
+			_effect = Core.Content.LoadEffect("Content/nez/effects/transitions/Kaleidoscope.mgfxo");
+			Speed = 1.0f;
+			Angle = 1.0f;
+			Power = 1.5f;
 		}
 
-		public WindowSliceTransition() : this(null)
+		public KaleidoscopeTransition() : this(null)
 		{ }
 
 		public override IEnumerator OnBeginTransition()
 		{
-			yield return null;
-
 			// load up the new Scene
 			yield return Core.StartCoroutine(LoadNextScene());
 

--- a/Nez.Portable/Graphics/Transitions/PerlinTransition.cs
+++ b/Nez.Portable/Graphics/Transitions/PerlinTransition.cs
@@ -9,27 +9,36 @@ using Nez.Tweens;
 namespace Nez
 {
 	/// <summary>
-	/// A cascade of opening vertical blinds
-	/// based on: https://gl-transitions.com/editor/windowslice
+	/// Dissolve using a generated Perlin noise pattern
+	/// based on: https://gl-transitions.com/editor/perlin
 	/// </summary>
-	public class WindowSliceTransition : SceneTransition
+	public class PerlinTransition : SceneTransition
 	{
 		/// <summary>
-		/// Number of window slices. Defaults to 10. (1 - 100)
+		/// Scale of the noise. Defaults to 4.0
 		/// </summary>
-		/// <value>The number of slices.</value>
-		public float Count
+		/// <value>The scale of the Perlin noise.</value>
+		public float Scale
 		{
-			set => _effect.Parameters["_count"].SetValue(value);
+			set => _effect.Parameters["_scale"].SetValue(value);
 		}
 
 		/// <summary>
-		/// Duration and speed of each slice. Defaults to 0.5. (0.0 - 1.0) 
+		/// Smoothness of the noise. Defaults to 0.01. (0.0 - 1.0)
 		/// </summary>
-		/// <value>The smoothness amount.</value>
+		/// <value>The smoothness of the noise pattern</value>
 		public float Smoothness
 		{
 			set => _effect.Parameters["_smoothness"].SetValue(value);
+		}
+
+		/// <summary>
+		/// Seed for the Perlin noise. Defaults to 12.9898
+		/// </summary>
+		/// <value>The seed for the noise generator</value>
+		public float Seed
+		{
+			set => _effect.Parameters["_seed"].SetValue(value);
 		}
 
 		/// <summary>
@@ -45,18 +54,18 @@ namespace Nez
 		Effect _effect;
 		Rectangle _destinationRect;
 
-
-		public WindowSliceTransition(Func<Scene> sceneLoadAction) : base(sceneLoadAction, true)
+		public PerlinTransition(Func<Scene> sceneLoadAction) : base(sceneLoadAction, true)
 		{
 			_destinationRect = PreviousSceneRender.Bounds;
 
 			// load Effect and set defaults
-			_effect = Core.Content.LoadEffect("Content/nez/effects/transitions/WindowSlice.mgfxo");
-			Count = 10;
-			Smoothness = 0.5f;
+			_effect = Core.Content.LoadEffect("Content/nez/effects/transitions/Perlin.mgfxo");
+			Scale = 4.0f;
+			Smoothness = 0.01f;
+			Seed = 12.9898f;
 		}
 
-		public WindowSliceTransition() : this(null)
+		public PerlinTransition() : this(null)
 		{ }
 
 		public override IEnumerator OnBeginTransition()

--- a/Nez.Portable/Graphics/Transitions/PolkaDotsCurtainTransition.cs
+++ b/Nez.Portable/Graphics/Transitions/PolkaDotsCurtainTransition.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using Nez.Tweens;
+
+namespace Nez
+{
+	/// <summary>
+	/// Grid of dots that grow. No aspect ratio correction
+	/// based on: https://gl-transitions.com/editor/PolkaDotsCurtain
+	/// </summary>
+	public class PolkaDotsCurtainTransition : SceneTransition
+	{
+		/// <summary>
+		/// Number of dots per axis. Defaults to 20.
+		/// </summary>
+		/// <value>The number of dots per axis.</value>
+		public float Dots
+		{
+			set => _effect.Parameters["_dots"].SetValue(value);
+		}
+
+		/// <summary>
+		/// Origin of dots animating. Defaults to Vector2(0, 0). "Top-Left"
+		/// </summary>
+		/// <value>The center origin.</value>
+		public Vector2 Center
+		{
+			set => _effect.Parameters["_center"].SetValue(value);
+		}
+
+		/// <summary>
+		/// duration for the transition
+		/// </summary>
+		public float Duration = 1f;
+
+		/// <summary>
+		/// ease equation to use for the animation
+		/// </summary>
+		public EaseType EaseType = EaseType.Linear;
+
+		Effect _effect;
+		Rectangle _destinationRect;
+
+		public PolkaDotsCurtainTransition(Func<Scene> sceneLoadAction) : base(sceneLoadAction, true)
+		{
+			_destinationRect = PreviousSceneRender.Bounds;
+
+			// load Effect and set defaults
+			_effect = Core.Content.LoadEffect("Content/nez/effects/transitions/PolkaDotsCurtain.mgfxo");
+			Center = new Vector2(0, 0);
+			Dots = 20f;
+		}
+
+		public override IEnumerator OnBeginTransition()
+		{
+			yield return null;
+
+			// load up the new Scene
+			yield return Core.StartCoroutine(LoadNextScene());
+
+			// apply the effect
+			yield return Core.StartCoroutine(TickEffectProgressProperty(_effect, Duration, EaseType));
+
+			TransitionComplete();
+
+			// cleanup
+			Core.Content.UnloadEffect(_effect);
+		}
+
+		public override void Render(Batcher batcher)
+		{
+			Core.GraphicsDevice.SetRenderTarget(null);
+			batcher.Begin(BlendState.NonPremultiplied, Core.DefaultSamplerState, DepthStencilState.None, null, _effect);
+			batcher.Draw(PreviousSceneRender, _destinationRect, Color.White);
+			batcher.End();
+		}
+	}
+}

--- a/Nez.Portable/Graphics/Transitions/PolkaDotsCurtainTransition.cs
+++ b/Nez.Portable/Graphics/Transitions/PolkaDotsCurtainTransition.cs
@@ -24,6 +24,15 @@ namespace Nez
 		}
 
 		/// <summary>
+		/// Aspect ratio of the screen. Defaults to Screen.Width/Height
+		/// </summary>
+		/// <value>Ratio of the screen.</value>
+		public float Ratio
+		{
+			set => _effect.Parameters["_ratio"].SetValue(value);
+		}
+
+		/// <summary>
 		/// Origin of dots animating. Defaults to Vector2(0, 0). "Top-Left"
 		/// </summary>
 		/// <value>The center origin.</value>
@@ -51,6 +60,7 @@ namespace Nez
 
 			// load Effect and set defaults
 			_effect = Core.Content.LoadEffect("Content/nez/effects/transitions/PolkaDotsCurtain.mgfxo");
+			Ratio = (float)Screen.Width / Screen.Height;
 			Center = new Vector2(0, 0);
 			Dots = 20f;
 		}

--- a/Nez.Portable/Graphics/Transitions/PolkaDotsCurtainTransition.cs
+++ b/Nez.Portable/Graphics/Transitions/PolkaDotsCurtainTransition.cs
@@ -55,6 +55,9 @@ namespace Nez
 			Dots = 20f;
 		}
 
+		public PolkaDotsCurtainTransition() : this(null)
+		{ }
+
 		public override IEnumerator OnBeginTransition()
 		{
 			yield return null;

--- a/Nez.Portable/Graphics/Transitions/SimpleZoomTransition.cs
+++ b/Nez.Portable/Graphics/Transitions/SimpleZoomTransition.cs
@@ -45,6 +45,9 @@ namespace Nez
 			ZoomQuickness = 0.8f;
 		}
 
+		public SimpleZoomTransition() : this(null)
+		{ }
+
 		public override IEnumerator OnBeginTransition()
 		{
 			yield return null;

--- a/Nez.Portable/Graphics/Transitions/SimpleZoomTransition.cs
+++ b/Nez.Portable/Graphics/Transitions/SimpleZoomTransition.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using Nez.Tweens;
+
+namespace Nez
+{
+	/// <summary>
+	/// Zoom in while blurring
+	/// based on: https://gl-transitions.com/editor/SimpleZoom
+	/// </summary>
+	public class SimpleZoomTransition : SceneTransition
+	{
+		/// <summary>
+		/// Speed of the zoom. Defaults to 0.8. (0.2 - 1.0)
+		/// </summary>
+		/// <value>The zoom quickness.</value>
+		public float ZoomQuickness
+		{
+			set => _effect.Parameters["_zoomQuickness"].SetValue(Mathf.Clamp(value, 0.2f, 1.0f));
+		}
+
+		/// <summary>
+		/// duration for the transition
+		/// </summary>
+		public float Duration = 1f;
+
+		/// <summary>
+		/// ease equation to use for the animation
+		/// </summary>
+		public EaseType EaseType = EaseType.Linear;
+
+		Effect _effect;
+		Rectangle _destinationRect;
+
+		public SimpleZoomTransition(Func<Scene> sceneLoadAction) : base(sceneLoadAction, true)
+		{
+			_destinationRect = PreviousSceneRender.Bounds;
+
+			// load Effect and set defaults
+			_effect = Core.Content.LoadEffect("Content/nez/effects/transitions/SimpleZoom.mgfxo");
+			ZoomQuickness = 0.8f;
+		}
+
+		public override IEnumerator OnBeginTransition()
+		{
+			yield return null;
+
+			// load up the new Scene
+			yield return Core.StartCoroutine(LoadNextScene());
+
+			// apply the effect
+			yield return Core.StartCoroutine(TickEffectProgressProperty(_effect, Duration, EaseType));
+
+			TransitionComplete();
+
+			// cleanup
+			Core.Content.UnloadEffect(_effect);
+		}
+
+		public override void Render(Batcher batcher)
+		{
+			Core.GraphicsDevice.SetRenderTarget(null);
+			batcher.Begin(BlendState.NonPremultiplied, Core.DefaultSamplerState, DepthStencilState.None, null, _effect);
+			batcher.Draw(PreviousSceneRender, _destinationRect, Color.White);
+			batcher.End();
+		}
+	}
+}

--- a/Nez.Portable/Graphics/Transitions/WaterDropTransition.cs
+++ b/Nez.Portable/Graphics/Transitions/WaterDropTransition.cs
@@ -9,27 +9,27 @@ using Nez.Tweens;
 namespace Nez
 {
 	/// <summary>
-	/// A cascade of opening vertical blinds
-	/// based on: https://gl-transitions.com/editor/windowslice
+	/// Ripples on water surface
+	/// based on: https://gl-transitions.com/editor/WaterDrop
 	/// </summary>
-	public class WindowSliceTransition : SceneTransition
+	public class WaterDropTransition : SceneTransition
 	{
 		/// <summary>
-		/// Number of window slices. Defaults to 10. (1 - 100)
+		/// Amplitude of the ripples. Defaults to 30.
 		/// </summary>
-		/// <value>The number of slices.</value>
-		public float Count
+		/// <value>The amplitude of the ripples.</value>
+		public float Amplitude
 		{
-			set => _effect.Parameters["_count"].SetValue(value);
+			set => _effect.Parameters["_amplitude"].SetValue(value);
 		}
 
 		/// <summary>
-		/// Duration and speed of each slice. Defaults to 0.5. (0.0 - 1.0) 
+		/// Speed of ripple propagation. Defaults to 30.
 		/// </summary>
-		/// <value>The smoothness amount.</value>
-		public float Smoothness
+		/// <value>The speed of the ripples.</value>
+		public float Speed
 		{
-			set => _effect.Parameters["_smoothness"].SetValue(value);
+			set => _effect.Parameters["_speed"].SetValue(value);
 		}
 
 		/// <summary>
@@ -45,18 +45,17 @@ namespace Nez
 		Effect _effect;
 		Rectangle _destinationRect;
 
-
-		public WindowSliceTransition(Func<Scene> sceneLoadAction) : base(sceneLoadAction, true)
+		public WaterDropTransition(Func<Scene> sceneLoadAction) : base(sceneLoadAction, true)
 		{
 			_destinationRect = PreviousSceneRender.Bounds;
 
 			// load Effect and set defaults
-			_effect = Core.Content.LoadEffect("Content/nez/effects/transitions/WindowSlice.mgfxo");
-			Count = 10;
-			Smoothness = 0.5f;
+			_effect = Core.Content.LoadEffect("Content/nez/effects/transitions/WaterDrop.mgfxo");
+			Amplitude = 30f;
+			Speed = 30f;
 		}
 
-		public WindowSliceTransition() : this(null)
+		public WaterDropTransition() : this(null)
 		{ }
 
 		public override IEnumerator OnBeginTransition()

--- a/Nez.Portable/Graphics/Transitions/WindowBlindsTransition.cs
+++ b/Nez.Portable/Graphics/Transitions/WindowBlindsTransition.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using Nez.Tweens;
+
+namespace Nez
+{
+	/// <summary>
+	/// Shrinking horizontal blinds with fade
+	/// based on: https://gl-transitions.com/editor/windowblinds
+	/// </summary>
+	public class WindowBlindsTransition : SceneTransition
+	{
+		/// <summary>
+		/// duration for the transition
+		/// </summary>
+		public float Duration = 1f;
+
+		/// <summary>
+		/// ease equation to use for the animation
+		/// </summary>
+		public EaseType EaseType = EaseType.Linear;
+
+		Effect _effect;
+		Rectangle _destinationRect;
+
+
+		public WindowBlindsTransition(Func<Scene> sceneLoadAction) : base(sceneLoadAction, true)
+		{
+			_destinationRect = PreviousSceneRender.Bounds;
+
+			// load Effect and set defaults
+			_effect = Core.Content.LoadEffect("Content/nez/effects/transitions/WindowBlinds.mgfxo");
+		}
+
+		public WindowBlindsTransition() : this(null)
+		{ }
+
+		public override IEnumerator OnBeginTransition()
+		{
+			yield return null;
+
+			// load up the new Scene
+			yield return Core.StartCoroutine(LoadNextScene());
+
+			// apply the effect
+			yield return Core.StartCoroutine(TickEffectProgressProperty(_effect, Duration, EaseType));
+
+			TransitionComplete();
+
+			// cleanup
+			Core.Content.UnloadEffect(_effect);
+		}
+
+		public override void Render(Batcher batcher)
+		{
+			Core.GraphicsDevice.SetRenderTarget(null);
+			batcher.Begin(BlendState.NonPremultiplied, Core.DefaultSamplerState, DepthStencilState.None, null, _effect);
+			batcher.Draw(PreviousSceneRender, _destinationRect, Color.White);
+			batcher.End();
+		}
+	}
+}

--- a/Nez.Portable/Graphics/Transitions/WindowSliceTransition.cs
+++ b/Nez.Portable/Graphics/Transitions/WindowSliceTransition.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using Nez.Tweens;
+
+namespace Nez
+{
+	/// <summary>
+	/// A cascade of opening vertical blinds
+	/// based on: https://gl-transitions.com/editor/windowslice
+	/// </summary>
+	public class WindowSliceTransition : SceneTransition
+	{
+		/// <summary>
+		/// Number of window slices. Defaults to 10. (1 - 100)
+		/// </summary>
+		/// <value>The number of slices.</value>
+		public float Count
+		{
+			set => _effect.Parameters["_count"].SetValue(value);
+		}
+
+		/// <summary>
+		/// Duration and speed of each slice. Defaults to 0.5. (0.0 - 1.0) 
+		/// </summary>
+		/// <value>The smoothness amount.</value>
+		public float Smoothness
+		{
+			set => _effect.Parameters["_smoothness"].SetValue(value);
+		}
+
+		/// <summary>
+		/// duration for the transition
+		/// </summary>
+		public float Duration = 1f;
+
+		/// <summary>
+		/// ease equation to use for the animation
+		/// </summary>
+		public EaseType EaseType = EaseType.Linear;
+
+		Effect _effect;
+		Rectangle _destinationRect;
+
+
+		public WindowSliceTransition(Func<Scene> sceneLoadAction) : base(sceneLoadAction, true)
+		{
+			_destinationRect = PreviousSceneRender.Bounds;
+
+			// load Effect and set defaults
+			_effect = Core.Content.LoadEffect("Content/nez/effects/transitions/WindowSlice.mgfxo");
+			Count = 10;
+			Smoothness = 0.5f;
+		}
+
+		public override IEnumerator OnBeginTransition()
+		{
+			yield return null;
+
+			// load up the new Scene
+			yield return Core.StartCoroutine(LoadNextScene());
+
+			// apply the effect
+			yield return Core.StartCoroutine(TickEffectProgressProperty(_effect, Duration, EaseType));
+
+			TransitionComplete();
+
+			// cleanup
+			Core.Content.UnloadEffect(_effect);
+		}
+
+		public override void Render(Batcher batcher)
+		{
+			Core.GraphicsDevice.SetRenderTarget(null);
+			batcher.Begin(BlendState.NonPremultiplied, Core.DefaultSamplerState, DepthStencilState.None, null, _effect);
+			batcher.Draw(PreviousSceneRender, _destinationRect, Color.White);
+			batcher.End();
+		}
+	}
+}


### PR DESCRIPTION
Adds 11 scene transitions using shaders, converted from gl-transitions.com.
These all-new transitions are one-part type and include configurable parameters:
Bounce
CircleCrop
DirectionalWipe
Doom
Kaleidoscope
Perlin
PolkaDotsCurtain
SimpleZoom
WaterDrop
WindowBlinds
WindowSlice

@prime31 will need to compile the shaders .mgofx/.fxb into the content