### PR TITLE
Scissor Test: Reduce memory consumption

### DIFF
--- a/Nez.Portable/Graphics/Batcher/Batcher.cs
+++ b/Nez.Portable/Graphics/Batcher/Batcher.cs
@@ -48,6 +48,7 @@ namespace Nez
 		SamplerState _samplerState;
 		DepthStencilState _depthStencilState;
 		RasterizerState _rasterizerState;
+		RasterizerState _scissorTestRasterizerState = new RasterizerState();
 		bool _disableBatching;
 
 		// How many sprites are in the current batch?
@@ -1041,15 +1042,14 @@ namespace Nez
 
 			FlushBatch();
 
-			_rasterizerState = new RasterizerState
-			{
-				CullMode = _rasterizerState.CullMode,
-				DepthBias = _rasterizerState.DepthBias,
-				FillMode = _rasterizerState.FillMode,
-				MultiSampleAntiAlias = _rasterizerState.MultiSampleAntiAlias,
-				SlopeScaleDepthBias = _rasterizerState.SlopeScaleDepthBias,
-				ScissorTestEnable = shouldEnable
-			};
+			_scissorTestRasterizerState.CullMode = _rasterizerState.CullMode;
+			_scissorTestRasterizerState.DepthBias = _rasterizerState.DepthBias;
+			_scissorTestRasterizerState.FillMode = _rasterizerState.FillMode;
+			_scissorTestRasterizerState.MultiSampleAntiAlias = _rasterizerState.MultiSampleAntiAlias;
+			_scissorTestRasterizerState.SlopeScaleDepthBias = _rasterizerState.SlopeScaleDepthBias;
+			_scissorTestRasterizerState.ScissorTestEnable = shouldEnable;
+			
+			_rasterizerState = _scissorTestRasterizerState;
 		}
 
 		void PrepRenderState()


### PR DESCRIPTION
When using a UI element which enables scissor test like ScrollPane, memory consumption rapidly grows.
This is due to the fact that two new RasterizeState instances will be created on every Draw call: 

- https://github.com/prime31/Nez/blob/master/Nez.Portable/UI/Containers/ScrollPane.cs#L1289-L1291
- https://github.com/prime31/Nez/blob/master/Nez.Portable/Graphics/Batcher/Batcher.cs#L1044-L1052

![nez_rasterize_state](https://github.com/user-attachments/assets/5fc7cad3-fb74-44a9-bd1f-064ae93aa288)

In 90 seconds nearly 11000 instances (~1 MB) will be created.

To avoid this, I introduced a new field in the Batcher-class. So instead of creating a new instance of the class every time, only this field will be updated.

Do you have any concerns regarding this change or is there maybe a better solution to solve this?
I tested this change and didn't see any negative side effects.