### PR TITLE
tiled object: merge properties dict with dict from template

### DIFF
--- a/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
@@ -487,6 +487,19 @@ namespace Nez.Tiled
 				}
 			}
 
+			// obj.Properties might already have data from the above template, 
+			// so merge-in xObject's properties dict with the values from template
+			var properties = ParsePropertyDict(xObject.Element("properties"));
+			if (properties != null)
+			{
+				if (obj.Properties == null)
+					obj.Properties = new Dictionary<string, string>();
+
+				foreach (KeyValuePair<string, string> property in properties)
+					obj.Properties[property.Key] = property.Value;
+			}
+
+
 			obj.Id = (int?)xObject.Attribute("id") ?? (int?)obj.Id ?? 0;
 			obj.Name = (string)xObject.Attribute("name") ?? obj.Name ?? string.Empty;
 			obj.X = (float)xObject.Attribute("x");
@@ -538,7 +551,6 @@ namespace Nez.Tiled
 				obj.ObjectType = TmxObjectType.Basic;
 			}
 
-			obj.Properties = ParsePropertyDict(xObject.Element("properties"));
 
 			return obj;
 		}


### PR DESCRIPTION
when a Tiled object is instantiated from a "tiled template" (more xml from an external .tx file, which Nez already supports), the 'Properties' node from the template node does get correctly consumed into the object.

However, near the end of the instantiation routine, the object-local 'Properties' node is loaded and this overwrites that entire template-loaded node. Ideally template values get loaded first and then object-local values merged into that.

So this code makes it do a merge-and-replace - template values are loaded first, then the object-local values are merged over those. Thus we have something closer to Tiled's 'spec' for how template fields are handled.

I've also relocated this logic a bit earlier to just after where the template values would get loaded, for better code locality.