### PR TITLE
Remove duplicate PingPong animation code

### DIFF
--- a/Nez.Portable/ECS/Components/Renderables/Sprites/SpriteAnimator.cs
+++ b/Nez.Portable/ECS/Components/Renderables/Sprites/SpriteAnimator.cs
@@ -158,16 +158,6 @@ namespace Nez.Sprites
 						break;
 					}
 					
-					switch (PingPongLoopState)
-					{
-						case PingPongLoopStates.Ping:
-							ParsePingLoop();
-							break;
-						case PingPongLoopStates.Pong:
-							ParsePongLoop();
-							break;
-					}
-
 					ParsePingPongLoop();
 					break;
 				case LoopMode.PingPongOnce:


### PR DESCRIPTION
The code that control the frames for the LoopMode.PingPong was being called twice.
This removes the first call, fixing the issue #878 .