### PR TITLE
Added Keys.Delete to GetChar() in KeysExt.cs

### DIFF
--- a/Nez.Portable/Utils/Extensions/KeysExt.cs
+++ b/Nez.Portable/Utils/Extensions/KeysExt.cs
@@ -161,6 +161,9 @@ namespace Nez
 
 			if (key == Keys.Back)
 				return (char) 8;
+			
+			if (key == Keys.Delete)
+				return (char) 127;
 
 
 			if (key == Keys.Add)


### PR DESCRIPTION
In Stage.UpdateKeyboardState(), key.GetChar() must return a value for _keyboardFocusElement.KeyPressed(key, c.Value) to be called.

Currently, Keys.Delete returns null, so KeyPressed() is not triggered for it. However, TextField's IKeyboardListener.KeyPressed() method checks for Keys.Delete:

    var deletePressed = key == Keys.Delete;

Because KeyPressed() is never called, deletePressed is not set to true, and the Delete key doesn't work as expected in text fields.

This fixed the delete key not working in a TextField.