### PR TITLE
Stopped TiledMapLoader from overwriting 'obj.Type' when loaded from a template

### DIFF
--- a/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
@@ -506,7 +506,7 @@ namespace Nez.Tiled
 			obj.Y = (float)xObject.Attribute("y");
 			obj.Width = (float?)xObject.Attribute("width") ?? (float?)obj.Width ?? 0.0f;
 			obj.Height = (float?)xObject.Attribute("height") ?? (float?)obj.Height ?? 0.0f;
-			obj.Type = (string)xObject.Attribute("type") ?? (string)xObject.Attribute("class") ?? string.Empty;
+			obj.Type = (string)xObject.Attribute("type") ?? (string)xObject.Attribute("class") ?? (string)obj.Type ?? string.Empty;
 			obj.Visible = (bool?)xObject.Attribute("visible") ?? true;
 			obj.Rotation = (float?)xObject.Attribute("rotation") ?? (float?)obj.Rotation ?? 0.0f;
 


### PR DESCRIPTION
TiledMapLoader successfully loads the 'Type' string of a TmxObject with a template on line 486: 
obj = new TmxObject().LoadTmxObjectFromTemplate(map, xDocTemplate.Element("template").Element("object"));

But this was not being checked before setting it to an empty string on line 509:
obj.Type = (string)xObject.Attribute("type") ?? (string)xObject.Attribute("class") ?? string.Empty;

This change prevents the correct Type attribute from being overwritten.