### PR TITLE
Adding Additional Tiled Support

### DIFF
--- a/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
@@ -184,16 +184,18 @@ namespace Nez.Tiled
 				var pval = string.Empty;
 				if (isClass)
 				{
-					// Loop through sub elements and pull name/value for dict
-					foreach (var subP in p.Elements("properties").DescendantNodes())
+					// Loop through all descendant properties
+					foreach (var descendantProperty in p.Descendants())
 					{
-						if (subP is XElement element)
+						// If the property has no attributes or is a class skip it
+						if (!descendantProperty.HasAttributes || descendantProperty.Attribute("type")?.Value == "class")
 						{
-							pname = element.Attribute("name")?.Value;
-							pval = element.Attribute("value")?.Value ?? element.Value;
-
-							dict.Add(pname, pval);
+							continue;
 						}
+
+						pname = descendantProperty.Attribute("name")?.Value;
+						pval = descendantProperty.Attribute("value")?.Value;
+						dict.Add(pname, pval);
 					}
 				}
 				else


### PR DESCRIPTION
This PR is an extension on the previous one, https://github.com/prime31/Nez/pull/841. Where the original had a limit of one nested layer, this PR aims to extend the functionality to pull all descendant properties in an effort to pull all values regardless of nesting depth. It does so by looping through all `Descendants()`, skipping classes or lines without value, and adding them to the dictionary.

Take the following tmx example with accompanying screenshot from Tiled: In here, there's the following:
- `CustomClassTest`, a class, holding an int with a value of 1 and a string called with a value of `TEST STRING`,
- `CustomEnumData`, another class, holding a single string `ITEM_ACCESSORY_PUMPKIN`,
- `CustomShopData`, another class, holding another class called `Items` that contains three enums. Those enums are comma separated strings.

```
<object id="1" x="224" y="64">
 <properties>
  <property name="CustomClassTest" type="class" propertytype="CustomClassStringTest">
   <properties>
    <property name="TestInt1" type="int" value="1"/>
    <property name="TestString1" value="TEST STRING"/>
   </properties>
  </property>
  <property name="CustomEnumData" propertytype="Accessories" value="ITEM_ACCESSORY_PUMPKIN"/>
  <property name="CustomShopData" type="class" propertytype="ShopData">
   <properties>
    <property name="items" type="class" propertytype="Items">
     <properties>
      <property name="Accessories" propertytype="Accessories" value="ITEM_ACCESSORY_PUMPKIN"/>
      <property name="Consumables" propertytype="Consumables" value="ITEM_CONSUMABLE_COFFEE,ITEM_CONSUMABLE_ROCKETS"/>
      <property name="Weapons" propertytype="Weapons" value="ITEM_WEAPON_PORCELAIN_CLAWS"/>
     </properties>
    </property>
   </properties>
  </property>
 </properties>
 <point/>
</object>
```
<img width="623" height="416" alt="image" src="https://github.com/user-attachments/assets/85f46ca4-421c-462d-a804-ce374c7fffaa" />

Using the proposed `Descendants()` logic we are able to gather all information

<img width="876" height="146" alt="image" src="https://github.com/user-attachments/assets/fb488e65-5ffb-4586-b99f-0ef2aaaa3b91" />
