### PR TITLE
FNA: Don't dispose target that is still bound

### DIFF
--- a/Nez.Portable/ECS/Scene.cs
+++ b/Nez.Portable/ECS/Scene.cs
@@ -375,6 +375,7 @@ namespace Nez
 
 			Camera = null;
 			Content.Dispose();
+			Core.GraphicsDevice.SetRenderTarget(null);
 			_sceneRenderTarget.Dispose();
 			Physics.Clear();
 


### PR DESCRIPTION
When using Vulkan/D3D12 I experienced severe problems like AccessViolationExceptions.
Luckily the FNA discord community helped me find the issue.

There's an oversight in NEZ in Scene#End(): https://github.com/prime31/Nez/blob/master/Nez.Portable/ECS/Scene.cs#L378
The RenderTarget will be disposed even though it's still bound. This never caused any issues with OpenGL/D3D11 because of the way the drivers determined the need to regenerate mipmaps.
The 'mipmap'-check is different in the SDL_GPU driver, which will lead to said AccessViolationExceptions.

A more detailed description can be found here: https://github.com/FNA-XNA/FNA/issues/553
The maintainers of FNA added a check in Dispose: https://github.com/FNA-XNA/FNA/commit/1cbe348a07b7d6de8159d5d14e475813bf76b3e9
Now an exception will be thrown if someone tries to dispose a still bound RenderTarget.

This means: Everyone using the most recent FNA version with NEZ will immediately be greeted with:
`Unhandled exception. System.InvalidOperationException: Disposing target that is still bound
   at Microsoft.Xna.Framework.Graphics.RenderTarget2D.Dispose(Boolean disposing) in FNA\src\Graphics\RenderTarget2D.cs:line 187
   at Microsoft.Xna.Framework.Graphics.GraphicsResource.Dispose() in FNA\src\Graphics\GraphicsResource.cs:line 133
   at Nez.Scene.End() in Nez\Nez.Portable\ECS\Scene.cs:line 378
   at Nez.Core.Update(GameTime gameTime) in Nez\Nez.Portable\Core.cs:line 264
`
when switching a scene. This exception will now be thrown regardless of the backend in use (OpenGL, D3D11, Vulkan, Metal, D3D12).

This PR should solve the issue. I'm still a little concerned about https://github.com/prime31/Nez/blob/master/Nez.Portable/ECS/Scene.cs#L382
I could imagine that _destinationRenderTarget.Dispose(); could also lead to this error in some circumstances.
I tested scene changes with and without postprocessors and could not reproduce the issue. That's why I only added Core.GraphicsDevice.SetRenderTarget(null); before _sceneRenderTarget.Dispose();

I tested the changes in my current game project and also with some sample setup with:
- FNA (latest version)
  - D3D11
  - OpenGL
  - Vulkan
  - D3D12
- Monogame  (3.8.0.1641)