### PR TITLE
Clear potential unprocessed raycast hits in RaycastResultParser.Reset()

### DIFF
--- a/Nez.Portable/Physics/SpatialHash.cs
+++ b/Nez.Portable/Physics/SpatialHash.cs
@@ -667,15 +667,9 @@ namespace Nez.Spatial
 			_checkedColliders.Clear();
 			_cellHits.Clear();
 
-#if DEBUG
-			// this *should* never happen if the ray cell traversal is working correctly, but leaving this debug test here for now just
-			// in case a missed edge case pops up.
-			if(_foreignCellHits.Count > 0)
-			{
-				Debug.Warn("{0} RaycastHit(s) were detected but never processed. This is a bug with Nez, please report it.", _foreignCellHits.Count);
-				_foreignCellHits.Clear();
-			}
-#endif
+			// if the raycast ends early because it filled the _hits array, then _foreignCellHits might
+			// still have a few unprocessed hits in it, so it needs to be cleared.
+			_foreignCellHits.Clear();
 		}
 	}
 }


### PR DESCRIPTION
Quick fix for something I overlooked in #895.

Since a raycast can end early if the provided `_hits` array is too small, it's possible for `_foreignCellHits` to have some remaining unprocessed hits when the cast ends, which means `_foreignCellHits` always needs to be cleared when the RaycastResultParser is reset. Otherwise these old hits might get added to future raycasts and cause mayhem. 🙃 