### PR TITLE
Fix: deferred lighting debug rendering

### DIFF
--- a/Nez.Portable/Graphics/DeferredLighting/DeferredLightingRenderer.cs
+++ b/Nez.Portable/Graphics/DeferredLighting/DeferredLightingRenderer.cs
@@ -138,6 +138,8 @@ namespace Nez.DeferredLighting
 				if (renderable.Enabled && renderable.IsVisibleFromCamera(cam))
 					renderable.DebugRender(Graphics.Instance.Batcher);
 			}
+			
+			base.DebugRender(scene, cam);
 		}
 
 


### PR DESCRIPTION
ez fix. if you were using DeferredLightingRenderer and wondered why some of the Debug drawing wasn't appearing.