### PR TITLE
adds getter for gamepad focus element

### DIFF
--- a/Nez.Portable/UI/Stage.cs
+++ b/Nez.Portable/UI/Stage.cs
@@ -787,10 +787,19 @@ namespace Nez.UI
 		/// </summary>
 		public void DisableGamepadFocus()
 		{
-    		_gamepadFocusElement = null;
-    		_isGamepadFocusEnabled = false;  
+			_gamepadFocusElement = null;
+			_isGamepadFocusEnabled = false;  
 		}
 
+		/// <summary>
+		/// Gets the element that the gamepad has focused.
+		/// </summary>
+		/// <returns>The keyboard focus.</returns>
+		public IGamepadFocusable GetGamepadFocusElement()
+		{
+			return _gamepadFocusElement;
+		}
+		
 		/// <summary>
 		/// Gets the element that will receive key events.
 		/// </summary>


### PR DESCRIPTION
this was handy for me in one case I needed to store the focused element to restore focus later. maybe it will be useful for others.