### PR TITLE
Tiled: loader support repeatX/Y props

### DIFF
--- a/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
+++ b/Nez.Portable/Assets/Tiled/Runtime/TiledMapLoader.cs
@@ -660,6 +660,9 @@ namespace Nez.Tiled
 			layer.ParallaxFactorX = (float?)xImageLayer.Attribute("parallaxx") ?? 1.0f;
 			layer.ParallaxFactorY = (float?)xImageLayer.Attribute("parallaxy") ?? 1.0f;
 
+			layer.RepeatX = (bool?)xImageLayer.Attribute("repeatx") ?? false;
+			layer.RepeatY = (bool?)xImageLayer.Attribute("repeaty") ?? false;
+
 			var xImage = xImageLayer.Element("image");
 			if (xImage != null)
 				layer.Image = new TmxImage().LoadTmxImage(xImage, tmxDir, contentManager);

--- a/Nez.Portable/Assets/Tiled/TiledTypes/ImageLayer.cs
+++ b/Nez.Portable/Assets/Tiled/TiledTypes/ImageLayer.cs
@@ -13,6 +13,9 @@ namespace Nez.Tiled
 		public float ParallaxFactorX { get; set; }
 		public float ParallaxFactorY { get; set; }
 
+		public bool RepeatX { get; set; }
+		public bool RepeatY { get; set; }
+
 		public int? Width;
 		public int? Height;
 


### PR DESCRIPTION
Tiled added the repeatx and repeaty props some time ago. These are primarily for Image Layers.