### PR TITLE
Add public setter to PointLight radius prop

### DIFF
--- a/Nez.Portable/Graphics/DeferredLighting/Lights/PointLight.cs
+++ b/Nez.Portable/Graphics/DeferredLighting/Lights/PointLight.cs
@@ -34,7 +34,7 @@ namespace Nez.DeferredLighting
 		/// <summary>
 		/// how far does this light reaches
 		/// </summary>
-		public float Radius => _radius;
+		public float Radius { get => _radius; set => SetRadius(value); }
 
 		/// <summary>
 		/// brightness of the light


### PR DESCRIPTION
**Doh I called it *getter* in the branch name ah well**

I needed to tween the light radius, and you need a public setter for that.

this change gets the job done. for future maybe could be candidate for slight refactor but risks breaking api perhaps.