### PR TITLE
SceneTransition progress tick routine - custom start/end

### DIFF
--- a/Nez.Portable/Graphics/Transitions/SceneTransition.cs
+++ b/Nez.Portable/Graphics/Transitions/SceneTransition.cs
@@ -196,11 +196,13 @@ namespace Nez
 		/// <param name="duration">duration</param>
 		/// <param name="reverseDirection">if true, _progress will go from 1 to 0. If false, it goes form 0 to 1</param>
 		public IEnumerator TickEffectProgressProperty(Effect effect, float duration,
-		                                              EaseType easeType = EaseType.ExpoOut,
-		                                              bool reverseDirection = false)
+														EaseType easeType = EaseType.ExpoOut,
+														bool reverseDirection = false,
+														float customStart = 0f,
+														float customEnd = 1f)
 		{
-			var start = reverseDirection ? 1f : 0f;
-			var end = reverseDirection ? 0f : 1f;
+			var start = reverseDirection ? customEnd : customStart;
+			var end = reverseDirection ? customStart : customEnd;
 			var progressParam = effect.Parameters["_progress"];
 
 			var elapsed = 0f;


### PR DESCRIPTION
Scene Transitions can be one-part or two-part variety.
both kinds of transition will tick the  _progress var from 0-to-1, but one-part transitions often employ use a time-symmetry or some kind of other mirror in their presentation or logic, so that both the front- and back-halves of the transition are played as progress goes 0->1. This means its natural half way point is when progress is 0.5.

A shortcoming of one-part transitions is you arent afforded a natural callback at that half way point. A transition shader could be reauthored to work in a two-part timelines manner, but that's extra work. 

With this little overload to allow for custom end (and start), one can repurpose an existing transition shader that was intended for one-part use, and use it in a two-part setup. We can tick progress from 0-to-0.5 for example, and then reverse it from 0.5-to-0, as a two-part would, and make use of the symmetry that many of the one-part transitions have naturally.