### PR TITLE
remove ImGui manager's EntityPane clipper; add counter

### DIFF
--- a/Nez.ImGui/Inspectors/SceneGraphPanes/EntityPane.cs
+++ b/Nez.ImGui/Inspectors/SceneGraphPanes/EntityPane.cs
@@ -4,32 +4,14 @@ namespace Nez.ImGuiTools.SceneGraphPanes
 {
 	public class EntityPane
 	{
-		/// <summary>
-		/// if this number of entites is exceeded we switch to a list clipper to keep things fast
-		/// </summary>
-		const int MIN_ENTITIES_FOR_CLIPPER = 100;
 		string _newEntityName = "";
 
 		unsafe public void Draw()
 		{
-			if (Core.Scene.Entities.Count > MIN_ENTITIES_FOR_CLIPPER)
-			{
-				var clipperPtr = ImGuiNative.ImGuiListClipper_ImGuiListClipper();
-				var clipper = new ImGuiListClipperPtr(clipperPtr);
-				
-				clipper.Begin(Core.Scene.Entities.Count, -1);
+			ImGui.Text("Count: " + Core.Scene.Entities.Count);
 
-				while (clipper.Step())
-					for (var i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
-						DrawEntity(Core.Scene.Entities[i]);
-
-				ImGuiNative.ImGuiListClipper_destroy(clipperPtr);
-			}
-			else
-			{
-				for (var i = 0; i < Core.Scene.Entities.Count; i++)
-					DrawEntity(Core.Scene.Entities[i]);
-			}
+			for (var i = 0; i < Core.Scene.Entities.Count; i++)
+				DrawEntity(Core.Scene.Entities[i]);
 
 			NezImGui.MediumVerticalSpace();
 			if (NezImGui.CenteredButton("Create Entity", 0.6f))
@@ -66,7 +48,7 @@ namespace Nez.ImGuiTools.SceneGraphPanes
 
 			// we are looking for a double-click that is not on the arrow
 			if (ImGui.IsMouseDoubleClicked(0) && ImGui.IsItemClicked() &&
-			    (ImGui.GetMousePos().X - ImGui.GetItemRectMin().X) > ImGui.GetTreeNodeToLabelSpacing())
+				(ImGui.GetMousePos().X - ImGui.GetItemRectMin().X) > ImGui.GetTreeNodeToLabelSpacing())
 			{
 				Core.GetGlobalManager<ImGuiManager>().StartInspectingEntity(entity);
 			}


### PR DESCRIPTION
The list clipper code was never going to work with our tree-based entity list. From the look and feel on this issue from upstreamers,  it seems the problem may be on us to solve, meaning generating our own flattened out list each frame. This wouldnt be very performant because of the recursive nesting and interacting with the imguinet wrapper to synch which tree nodes are "open" and not, etc.

Viewed against what it was trying to do which was improve perf in the list. It doesnt actually do that with the current code because the layout is busted anyway. And upping the limit is arbitrary while perf seems good all around already.

In my pursuits I found having the regular list be longer than the prescribed 100, and up to 300, was no sweat for my 15-year-old intel laptop. And this is for debuggers' use.

So I have removed it. And I added a little subheader text to display the entity count.

PS. for a practical perf at this stage, it may be worth looking into doing a simple bounds-visible check before drawing each row, skipping some of the logic and layout at least in theory. however, this also faces the problem when using tree/nested listing, that the count is not precomputed and the offsets not trivial to get.