### PR TITLE
fix vertical alignment being flipped in Element.setPosition

### DIFF
--- a/Nez.Portable/UI/Base/Element.cs
+++ b/Nez.Portable/UI/Base/Element.cs
@@ -202,9 +202,9 @@ namespace Nez.UI
 			else if ((alignment & AlignInternal.Left) == 0) //
 				x -= width / 2;
 
-			if ((alignment & AlignInternal.Top) != 0)
+			if ((alignment & AlignInternal.Bottom) != 0)
 				y -= height;
-			else if ((alignment & AlignInternal.Bottom) == 0) //
+			else if ((alignment & AlignInternal.Top) == 0) //
 				y -= height / 2;
 
 			if (this.x != x || this.y != y)


### PR DESCRIPTION
Since Nez UI has the y-axis pointing down, instead of y-axis pointing up like the original libgdx scene2d, the vertical alignment calculations need to be flipped. This was already done for e.g. GetY(int alignment).
This PR also fixes it for SetPosition(float x, float y, int alignment).

Also similar to this pull request here fixing container alignment: https://github.com/prime31/Nez/pull/796
