### PR TITLE
Fix ScrollPane Issues

### DIFF
--- a/Nez.Portable/UI/Containers/ScrollPane.cs
+++ b/Nez.Portable/UI/Containers/ScrollPane.cs
@@ -1239,7 +1239,7 @@ namespace Nez.UI
 			else
 				eleY -= _visualAmountY;
 
-			float eleX = _widgetAreaBounds.Y;
+			float eleX = _widgetAreaBounds.X;
 			if (_scrollX)
 				eleX -= (int)_visualAmountX;
 

--- a/Nez.Portable/UI/Containers/ScrollPane.cs
+++ b/Nez.Portable/UI/Containers/ScrollPane.cs
@@ -1034,8 +1034,8 @@ namespace Nez.UI
 			}
 			else
 			{
-				if (x + width > amountX + _areaWidth) amountX = x + width - _areaWidth;
-				if (x < amountX) amountX = x;
+				if (amountX < x + width - _areaWidth) amountX = x + width - _areaWidth;
+				if (amountX > x) amountX = x;
 			}
 
 			SetScrollX(amountX);
@@ -1043,12 +1043,12 @@ namespace Nez.UI
 			var amountY = _amountY;
 			if (centerVertical)
 			{
-				amountY = _maxY - y + _areaHeight / 2 - height / 2;
+				amountY = y - _areaHeight / 2 + height / 2;
 			}
 			else
 			{
-				if (amountY > _maxY - y - height + _areaHeight) amountY = _maxY - y - height + _areaHeight;
-				if (amountY < _maxY - y) amountY = _maxY - y;
+				if (amountY < y + height - _areaHeight) amountY = y + height - _areaHeight;
+				if (amountY > y) amountY = y;
 			}
 
 			SetScrollY(amountY);


### PR DESCRIPTION
This just fixes two issues with the ScrollPane:

1. calculating the widget area position when rendering incorrectly used the Y coordinate in one place instead of the X coordinate. This means this probably went unnoticed for so long, because if both scrollbars are the same, it still works correctly. But e.g. disabling the horizontal scrollbar and having the vertical scrollbar on the left side, would cause the content to be rendered below the scrollbar.
2. ScrollPane's scrollTo method had the y-axis calculation flipped, it still did it the same way as LibGDX did. I have no idea how nobody noticed that yet. My conclusion is that nobody has used this method up to now. Anyway it's fixed now. 

(also refactored the X coordinate calculation to be more consistent with the rest, hope that's fine)